### PR TITLE
Add criterion 2.1.4 to list of all criterion

### DIFF
--- a/source/documentation/_all.md.erb
+++ b/source/documentation/_all.md.erb
@@ -65,6 +65,8 @@ Here are the details of all 50 success criteria.
 
 <%= partial "/documentation/2.1.2" %>
 
+<%= partial "/documentation/2.1.4" %>
+
 ### 2.2 Enough Time
 
 <%= partial "/documentation/2.2.1" %>


### PR DESCRIPTION
Criterion 2.1.4 was present on the 'code' page, but not present on the 'all' page. This adds it in.