### PR TITLE
Fixed error in 1.4.13: not obscuring content is an exception, not a requirement

### DIFF
--- a/source/documentation/1.4.13.md
+++ b/source/documentation/1.4.13.md
@@ -2,7 +2,7 @@
 
 This is for mobile or tablet devices - where pointer hover or keyboard focus triggers additional content to become visible and then hidden (like pops or other options) you need make sure:
 
-* The ‘extra’ content can be <strong>dismissed</strong> without moving focus and it does not obscure other page content.
+* The ‘extra’ content can be <strong>dismissed</strong> without moving focus, unless it does not obscure other page content.
 * If the user needs to <strong>hover or interact with the extra content</strong>, then the pointer can move to it and use it, without it disappearing. 
 * The content <strong>stays visible until focus is moved</strong>, or the user dismissed it, or it is no longer useful.
 


### PR DESCRIPTION
1.4.13 says that content displayed on focus needs to be dismissable without moving focus <strong>unless</strong> that extra content doesn't obscure any other page content.

The previous wording said 'and' instead of 'unless'.
