### PR TITLE
2.5.1. in Checklist: removed 'single tap' mistake; added simple gesture requirement

### DIFF
--- a/source/documentation/checklist.md
+++ b/source/documentation/checklist.md
@@ -37,7 +37,7 @@ Answering NO means that you are not meeting WCAG and your content will have barr
 * Are headings and labels clear and descriptive?
 * When using a keyboard to move through a page can you tell where you are?
 * Do you have shortcuts triggered by only one letter or character? If so can they be turned off or remapped by the user?
-* Does some of your site functionality need several fingers or complex gestures to operate it? If so, can the same functionality be used with just single taps or clicks?
+* Does some of your site functionality use several fingers or complex gestures? If so, can the same functionality be used with just one finger and simple gestures?
 * Does some of your site functionality work using a single point (e.g fingertip)? If so, have you ensured it doesn't get triggered the moment it is touched?
 * On forms and other components is the accessible name or label the same as any on-screen text? 
 * Does your site respond to motion or movement? If so, can responding to motion or movement be disabled, and your site still be fully usable?


### PR DESCRIPTION
This fixes two mistakes I made in a previous, already-merged PR.

##### 1. Fixed interpretation of 'single pointer'

'Single taps' is not a requirement for 2.5.1. (I had misinterpreted 'single pointer' in the WCAG). This new phrasing says 'one finger' to simplify the term 'single pointer', because I believe that only touchscreens use multipoint gestures.

##### 2. Mention 'simple gesture' as a requirement

Functionalities that use complex (i.e. path-based) gestures need to also work with just simple gestures. This was missing from the previous phrasing.