### PR TITLE
Fixed external link to article in 2.2.1

### DIFF
--- a/source/documentation/2.2.1.md
+++ b/source/documentation/2.2.1.md
@@ -13,4 +13,4 @@ When a time limit like a session timeout is set, it must be possible for the use
 
 ##### Useful resources
 
-*   [Accessible timeout notifications](https://www.google.co.uk/search?client=firefox-b-ab&q=tink.uk+%2B+alerts&oq=tink.uk+%2B+alerts&gs_l=serp.3...11843.19075.0.19198.33.31.2.0.0.0.222.2583.24j5j1.30.0....0...1.1.64.serp..1.28.2205.0..0j0i131k1j0i67k1j0i10i67k1j0i10k1j0i13k1j0i13i10k1j0i30k1j0i8i30k1j0i8i10i30k1j0i22i30k1j0i22i10i30k1j0i13i30k1j0i13i5i30k1j0i8i13i30k1j0i8i13i10i30k1j33i160k1j33i21k1.qfLU1yJF7Ig)
+*   [Accessible timeout notifications](https://tink.uk/accessible-timeout-notifications/)


### PR DESCRIPTION
In [2.2.1 Timing adjustable, under the 'Useful resources' header](https://alphagov.github.io/wcag-primer/all.html#2-2-1-timing-adjustable-a-useful-resources), the link named 'Accessible timeout notifications' currently points to a Google search result page. 

The first result on that page is Léonie Watson's 'Accessible timeout notifications' blog post. (All other links are irrelevant; the search term was "tink.uk   alerts").

I've fixed the link to point directly to Léonie's article.