### PR TITLE
Update WCAG-primer

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -15,6 +15,7 @@ header_links:
   Design: design.html
   Code: code.html
   Checklist: checklist.html
+  Community: community.html
 footer_links:
   Accessibility: /accessibility.html
 

--- a/source/community.html.md.erb
+++ b/source/community.html.md.erb
@@ -1,0 +1,5 @@
+---
+title: Community
+---
+
+<%= partial 'documentation/community' %>

--- a/source/documentation/community.md
+++ b/source/documentation/community.md
@@ -1,0 +1,11 @@
+# Community
+
+This WCAG Primer is for everyone.
+
+## Contributing
+
+You can help make sure it stays up to date by:
+
+1. Making changes to the [WCAG primer on Github](https://github.com/alphagov/wcag-primer).
+
+2. Emailing the Accessibility Capability team at <accessibility@digital.cabinet-office.gov.uk> with suggestions


### PR DESCRIPTION
## What

Add new page "Community" on public facing docs

## Why

So the wider (non Dev) a11y community knows how to add to this doc.  Based on a similar pattern found here: 
https://accessibility-manual.dwp.gov.uk/community

## Visuals 

![image](https://user-images.githubusercontent.com/71266765/126999425-d1722c27-3dd1-4c87-a6a5-e89175f380fd.png)

## Anything else

PR also in Content review for feedback.

