### PR TITLE
Add checklist links

### DIFF
--- a/source/documentation/2.3.1.md
+++ b/source/documentation/2.3.1.md
@@ -1,4 +1,4 @@
-#### [2.3.1 Three flashes or below (A)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html)
+#### [2.3.1 Three flashes or below threshold (A)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html)
 
 A page must not contain content that flashes more than three times a second. This ensures that people with conditions like photosensitive Epilepsy are protected from harmful seizures.
 

--- a/source/documentation/2.4.2.md
+++ b/source/documentation/2.4.2.md
@@ -1,4 +1,4 @@
-#### [2.4.2 Page title (A)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html)
+#### [2.4.2 Page titled (A)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html)
 
 Each page must have a unique title that indicates its topic or purpose. This ensures that people with cognitive disabilities can quickly orientate themselves within the service and identify the purpose of the page without interpreting its entire contents.
 

--- a/source/documentation/checklist.md
+++ b/source/documentation/checklist.md
@@ -1,15 +1,17 @@
 # Checklist
 
-To meet WCAG 2.1 to level AA you must be able to answer YES or Not Applicable to all of the following questions.
+To meet Web Content Accessibility Guidelines (WCAG) 2.1 to level AA you must be able to answer YES or Not Applicable to all of the following questions.
 
 Answering NO means that you are not meeting WCAG and your content will have barriers that will prevent some users, especially disabled users and older people from accessing it.
 
+Each link points to the relevant WCAG "understanding" page with more detail.
+
 ## Perceivable
-* Do all images have an appropriate text equivalent? Is essential visual information also available as text?
-* Do all audio files have a transcript? Is essential audio information available as text?
-* Do all videos have captions that are synchronised with the audio?
-* Does video that includes important visual information have an audio description?
-* Is all content structure that is communicated visually available to assistive technologies?
+* Do all images have an appropriate text equivalent? Is essential visual information also available as text? [1.1.1 Non-text content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)
+* Do all audio files have a transcript? Is essential audio information available as text? [1.2.1 Audio/video only](https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html)
+* Do all videos have captions that are synchronised with the audio? [1.2.2 Captions](https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html)
+* Does video that includes important visual information have an audio description? [1.2.5 Audio description](https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded.html)
+* Is all content structure that is communicated visually available to assistive technologies? [1.3.1 Info and relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)
 * If styling is removed is the content in a logical order?
 * Have you avoided using visual characteristics to communicate information?
 * Have you avoided using colour as the only way to convey some information?

--- a/source/documentation/checklist.md
+++ b/source/documentation/checklist.md
@@ -31,7 +31,7 @@ Answering NO means that you are not meeting WCAG and your content will have barr
 * Can any content that moves or auto updates be stopped? [2.2.1 Timing adjustable](/all.html#2-2-1-timing-adjustable-a) and [2.2.2 Pause, stop, hide](/all.html#2-2-2-pause-stop-hide-a)
 * Have you avoided using content that flashes or flickers? [2.3.1 Three flashes or below threshold](/all.html#2-3-1-three-flashes-or-below-threshold-a)
 * Can blocks of links and other interactive elements be bypassed by keyboard users? [2.4.1 Bypass blocks](/all.html#2-4-1-bypass-blocks-a)
-* Does each page have a unique title that indicates its purpose and context? [2.4.2 Page titled](/all.html#2-4-2-page-titled`~-a)
+* Does each page have a unique title that indicates its purpose and context? [2.4.2 Page titled](/all.html#2-4-2-page-titled-a)
 * When using a keyboard to move through a page does the order make sense? [2.4.3 Focus order](/all.html#2-4-3-focus-order-a)
 * Is the purpose of every link clear from its link text? [2.4.4 Link purpose in context](/all.html#2-4-4-link-purpose-in-context-a)
 * Does the website have two or more ways of finding content, such as a navigation menu, search feature, or site map? [2.4.5 Multiple ways](/all.html#2-4-5-multiple-ways-aa)

--- a/source/documentation/checklist.md
+++ b/source/documentation/checklist.md
@@ -4,54 +4,52 @@ To meet Web Content Accessibility Guidelines (WCAG) 2.1 to level AA you must be 
 
 Answering NO means that you are not meeting WCAG and your content will have barriers that will prevent some users, especially disabled users and older people from accessing it.
 
-Each link points to the relevant WCAG "understanding" page with more detail.
-
 ## Perceivable
-* Do all images have an appropriate text equivalent? Is essential visual information also available as text? [1.1.1 Non-text content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)
-* Do all audio files have a transcript? Is essential audio information available as text? [1.2.1 Audio/video only](https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html)
-* Do all videos have captions that are synchronised with the audio? [1.2.2 Captions](https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html)
-* Does video that includes important visual information have an audio description? [1.2.5 Audio description](https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded.html)
-* Is all content structure that is communicated visually available to assistive technologies? [1.3.1 Info and relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)
-* If styling is removed is the content in a logical order?
-* Have you avoided using visual characteristics to communicate information?
-* Have you avoided using colour as the only way to convey some information?
-* Can users stop audio that auto plays?
-* Does all text have sufficient contrast against the background colour?
-* Is the content fully usable when text is enlarged up to 200%?
-* Have you avoided using images of text?
-* Can users flip the content horizontally and vertically?  
-* Have you added HTML autocomplete tokens to any forms collecting information about the user?
-* Does the page content resize to a single column with no horizontal and vertical scrolling?
-* Do all important graphical objects, interface components, and states have a colour contrast of 3:1?  
-* Can line height, spacing between paragraphs and letter and word spacing be changed without breaking anything?
-* Where extra content is shown or hidden on focus, can it be dismissed, interacted with (and not disappear when the user moves to it) and will stay visible until dismissed by the user?
+* Do all images have an appropriate text equivalent? Is essential visual information also available as text? [1.1.1 Non-text content](/all.html#1-1-1-non-text-content-a)
+* Do all audio files have a transcript? Is essential audio information available as text? [1.2.1 Audio/video only (prerecorded)](all.html#1-2-1-audio-only-and-video-only-a)
+* Do all videos have captions that are synchronised with the audio? [1.2.2 Captions (prerecorded)](/all.html#1-2-2-captions-prerecorded-a) and [1.2.4 Captions (live)](/all.html#1-2-4-captions-live-aa)
+* Does video that includes important visual information have an audio description? [1.2.3 Audio description or media alternative](/all.html#1-2-3-audio-description-or-media-alternative-a) and [1.2.5 Audio description](/all.html#1-2-5-audio-description-pre-recorded-aa)
+* Is all content structure that is communicated visually available to assistive technologies? [1.3.1 Info and relationships](/all.html#1-3-1-info-and-relationships-a)
+* If styling is removed is the content in a logical order? [1.3.2 Meaningful sequence](/all.html#1-3-2-meaningful-sequence-a)
+* Have you avoided using visual characteristics to communicate information? [1.3.3 Sensory characteristics](/all.html#1-3-3-sensory-characteristics-a)
+* Can users flip the content horizontally and vertically? [1.3.4 Orientation](/all.html#1-3-4-orientation-a)
+* Have you added HTML autocomplete tokens to any forms collecting information about the user? [1.3.5 Identify input purpose](/all.html#1-3-5-identify-input-purpose-aa)
+* Have you avoided using colour as the only way to convey some information? [1.4.1 Use of colour](/all.html#1-4-1-use-of-colour-a)
+* Can users stop audio that auto plays? [1.4.2 Audio control](/all.html#1-4-2-audio-control-a)
+* Does all text have sufficient contrast against the background colour? [1.4.3 Contrast](/all.html#1-4-3-contrast-minimum-aa)
+* Is the content fully usable when text is enlarged up to 200%? [1.4.4 Resize text](/all.html#1-4-4-resize-text-aa)
+* Have you avoided using images of text? [1.4.5 Images of text](/all.html#1-4-5-images-of-text-aa)
+* Does the page content resize to a single column with no horizontal and vertical scrolling? [1.4.10 Reflow](/all.html#1-4-10-reflow-aa)
+* Do all important graphical objects, interface components, and states have a colour contrast of 3:1? [1.4.11 Non-text contrast](/all.html#1-4-11-non-text-contrast-aa)
+* Can line height, spacing between paragraphs and letter and word spacing be changed without breaking anything? [1.4.12 Text spacing](/all.html#1-4-12-text-spacing-aa)
+* Where extra content is shown or hidden on focus, can it be dismissed, interacted with (and not disappear when the user moves to it) and will stay visible until dismissed by the user? [1.4.13 Content on hover or focus](/all.html#1-4-13-content-on-hover-or-focus-aa)
 
 ## Operable
-* Can all menus, links, buttons, and other controls be operated by keyboard?
-* Do pages that have time limits include mechanisms for adjusting those limits?
-* Can any content that moves or auto updates be stopped?
-* Have you avoided using content that flashes or flickers?
-* Can blocks of links and other interactive elements be bypassed by keyboard users?
-* Does each page have a unique title that indicates its purpose and context?
-* When using a keyboard to move through a page does the order make sense?
-* Is the purpose of every link clear from its link text?
-* Does the website have two or more ways of finding content, such as a navigation menu, search feature, or site map?
-* Are headings and labels clear and descriptive?
-* When using a keyboard to move through a page can you tell where you are?
-* Do you have shortcuts triggered by only one letter or character? If so can they be turned off or remapped by the user?
-* Does some of your site functionality need several fingers or complex gestures to operate it? If so, can the same functionality be used with just single taps or clicks?
-* Does some of your site functionality work using a single point (e.g fingertip)? If so, have you ensured it does not get triggered the moment it is touched?
-* On forms and other components is the accessible name or label the same as any on-screen text?
-* Does your site respond to motion or movement? If so, can responding to motion or movement be disabled, and your site still be fully usable?
+* Can all menus, links, buttons, and other controls be operated by keyboard? [2.1.1 Keyboard](/all.html#2-1-1-keyboard-a)
+* Do pages that have time limits include mechanisms for adjusting those limits? [2.1.2 No keyboard trap](/all.html#2-1-2-no-keyboard-trap-a)
+* Do you have shortcuts triggered by only one letter or character? If so can they be turned off or remapped by the user? [2.1.4 Character key shortcuts](/all.html#2-1-4-character-key-shortcuts-a)
+* Can any content that moves or auto updates be stopped? [2.2.1 Timing adjustable](/all.html#2-2-1-timing-adjustable-a) and [2.2.2 Pause, stop, hide](/all.html#2-2-2-pause-stop-hide-a)
+* Have you avoided using content that flashes or flickers? [2.3.1 Three flashes or below threshold](/all.html#2-3-1-three-flashes-or-below-threshold-a)
+* Can blocks of links and other interactive elements be bypassed by keyboard users? [2.4.1 Bypass blocks](/all.html#2-4-1-bypass-blocks-a)
+* Does each page have a unique title that indicates its purpose and context? [2.4.2 Page titled](/all.html#2-4-2-page-titled`~-a)
+* When using a keyboard to move through a page does the order make sense? [2.4.3 Focus order](/all.html#2-4-3-focus-order-a)
+* Is the purpose of every link clear from its link text? [2.4.4 Link purpose in context](/all.html#2-4-4-link-purpose-in-context-a)
+* Does the website have two or more ways of finding content, such as a navigation menu, search feature, or site map? [2.4.5 Multiple ways](/all.html#2-4-5-multiple-ways-aa)
+* Are headings and labels clear and descriptive? [2.4.6 Headings and labels](/all.html#2-4-6-headings-and-labels-aa)
+* When using a keyboard to move through a page can you tell where you are? [2.4.7 Focus visible](/all.html#2-4-7-focus-visible-aa)
+* Does some of your site functionality need several fingers or complex gestures to operate it? If so, can the same functionality be used with just single taps or clicks? [2.5.1 Pointer gestures](/all.html#2-5-1-pointer-gestures-a)
+* Does some of your site functionality work using a single point (e.g fingertip)? If so, have you ensured it does not get triggered the moment it is touched? [2.5.2 Pointer cancellation](/all.html#2-5-2-pointer-cancellation-a)
+* On forms and other components is the accessible name or label the same as any on-screen text? [2.5.3 Label in name](/all.html#2-5-3-label-in-name-a)
+* Does your site respond to motion or movement? If so, can responding to motion or movement be disabled, and your site still be fully usable? [2.5.4 Motion actuation](/all.html#2-5-4-motion-actuation-a)
 
 ## Understandable
-* Has the language of the web page or document (or individual parts of a multilingual document) been defined?
-* Have you avoided links, controls, or form fields that automatically trigger a change in context?
-* Does the website include consistent navigation?
-* Are features with the same functionality labelled consistently?
-* Do forms provide helpful, understandable error and verification messages?
+* Has the language of the web page or document (or individual parts of a multilingual document) been defined? [3.1.1 Language of page](/all.html#3-1-1-language-of-page-a) and [3.1.2 Language of parts](/all.html#3-1-2-language-of-parts-aa)
+* Have you avoided links, controls, or form fields that automatically trigger a change in context? [3.2.1 On focus](/all.html#3-2-1-on-focus-a) and [3.2.2 On input](/all.html#3-2-2-on-input-a)
+* Does the website include consistent navigation? [3.2.3 Consistent navigation](/all.html#3-2-3-consistent-navigation-aa)
+* Are features with the same functionality labelled consistently? [3.2.4 Consistent identification](/all.html#3-2-4-consistent-identification-aa)
+* Do forms provide helpful, understandable error and verification messages? [3.3.1 Error identification](/all.html#3-3-1-error-identification-a), [3.3.2 Labels or instructions](/all.html#3-3-2-labels-or-instructions-a), [3.3.3 Error suggestion](/all.html#3-3-3-error-suggestion-aa) and [3.3.4 Error prevention](/all.html#3-3-4-error-prevention-legal-financial-data-aa)
 
 ## Robust
-* Is the web page coded using valid HTML?
-* Do all interactive components have an accessible name and role, and when required state? Has the correct ARIA markup been used and does it validate?
-* Are status messages and updates given appropriate roles that can be understood by AT, without receiving focus?
+* Is the web page coded using valid HTML? [4.1.1 Parsing](/all.html#4-1-1-parsing-a)
+* Do all interactive components have an accessible name and role, and when required state? Has the correct ARIA markup been used and does it validate? [4.1.2 Name, role, value](/all.html#4-1-2-name-role-value-a)
+* Are status messages and updates given appropriate roles that can be understood by AT, without receiving focus? [4.1.3 Status messages](/all.html#4-1-3-status-messages-aa)

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -28,11 +28,11 @@ WCAG 2.1 also helps us think about the different ways people use the web:
 * By using speech recognition to use the web with voice commands and dictation
 
 ## How does it relate to WCAG 2.0?
-WCAG 2.1 is built on 2.0. So content that passes  WCAG 2.1 will also also pass WCAG 2.0.
+WCAG 2.1 is built on 2.0. So content that passes WCAG 2.1 will also pass WCAG 2.0.
 
 
 ## New things in WCAG 2.1:
-WCAG 2.1 extends WCAG 2.0 by adding new success criteria, definitions, and guidelines to organize the additions. There are some additions to the conformance section.
+WCAG 2.1 extends WCAG 2.0 by adding new success criteria, definitions, and guidelines to organise the additions. There are some additions to the conformance section.
 
 ### New Success Criteria
 
@@ -79,7 +79,7 @@ Each of these responsive page ‘versions’ needs to pass (or have an alternati
 
 ## WCAG 2.1 architecture
 
-WCAG 2.1 has twelve guidelines, grouped into four principles. The principle are that content must be:
+WCAG 2.1 has twelve guidelines, grouped into four principles. The principles are that content must be:
 
 * Perceivable
 * Operable
@@ -107,7 +107,7 @@ Your service must present information in ways people can recognise and use, no m
 
 #### Guideline 1.2: Provide alternatives for time-based media
 * 1.2.1 Provide a text description for video content that has no audio, or a transcript for audio content that has no video, and make sure the description and transcript serve the same purpose as the original content. [More about 1.2.1](all.html#1-2-1-audio-only-and-video-only-a)
-* 1.2.2 Provide real-time captions for video content that has audio, and make sure the captions include all dialogue and important sound-effects. [More about 1.2.2](/all.html#1-2-2-captions-a)
+* 1.2.2 Provide real-time captions for video content that has audio, and make sure the captions include all dialogue and important sound-effects. [More about 1.2.2](/all.html#1-2-2-captions-prerecorded-a)
 * 1.2.3 Provide a text description or a transcript for video content that has audio, and make sure the description or transcript serves the same purpose as the original content. [More about 1.2.3](/all.html#1-2-3-audio-description-or-media-alternative-a)
 * 1.2.4 Provide real-time captions for live video content that has audio, and make sure the captions include all dialogue and important sound-effects. [More about 1.2.4](/all.html#1-2-4-captions-live-aa)
 * 1.2.5 Provide audio description for video content, and make sure the description includes all important activity that takes place on-screen. [More about 1.2.5](/all.html#1-2-5-audio-description-pre-recorded-aa)
@@ -116,8 +116,8 @@ Your service must present information in ways people can recognise and use, no m
 * 1.3.1 Use elements like headings, lists and tables to properly convey the structure of content. [More about 1.3.1](/all.html#1-3-1-info-and-relationships-a)
 * 1.3.2 Make sure content can always be read in a logical order even when stylesheets are disabled. [More about 1.3.2](/all.html#1-3-2-meaningful-sequence-a)
 * 1.3.3 Do not use colour, size, shape, sound or location as the only way to convey instructions. [More about 1.3.3](/all.html#1-3-3-sensory-characteristics-a)
-* 1.3.4 [New] Make sure a page view is not locked to either horizontal or vertical views only, unless this is essential. [More about 1.3.4](/all.html#1-3-4-orientation-aa)
-* 1.3.5 [New] In forms that collect information <strong>about the user</strong> add HTML autocomplete attributes to identify the purpose of the input. [More about 1.3.5](/all.html#1-3-5-input-purpose-aa)
+* 1.3.4 [New] Make sure a page view is not locked to either horizontal or vertical views only, unless this is essential. [More about 1.3.4](/all.html#1-3-4-orientation-a)
+* 1.3.5 [New] In forms that collect information <strong>about the user</strong> add HTML autocomplete attributes to identify the purpose of the input. [More about 1.3.5](/all.html#1-3-5-identify-input-purpose-aa)
 
 #### Guideline 1.4: Make content easy for people to see and hear
 * 1.4.1 Do not use colour as the only way to convey information of any kind. [More about 1.4.1](/all.html#1-4-1-use-of-colour-a)
@@ -128,7 +128,7 @@ Your service must present information in ways people can recognise and use, no m
 * 1.4.10 [New] Make sure content will reflow to a single column when zoomed and not produce scrolling in both directions. [More about 1.4.10](/all.html#1-4-10-reflow-aa)
 * 1.4.11 [New] Make sure sight impaired users can see important controls and understand graphics. [More about 1.4.11](/all.html#1-4-11-non-text-contrast-aa)
 * 1.4.12 [New] Make sure users can modify text line height, letter or word spacing. [More about 1.4.12](/all.html#1-4-12-text-spacing-aa)
-* 1.4.13 <strong>[New]</strong> Provide a way to control how people can interact with or dismiss any ‘extra’ content that becomes visible. [More about 1.4.13](/all.html#1-4-13-content-on-hover-or-focus-aa)
+* 1.4.13 [New] Provide a way to control how people can interact with or dismiss any ‘extra’ content that becomes visible. [More about 1.4.13](/all.html#1-4-13-content-on-hover-or-focus-aa)
 
 
 
@@ -146,14 +146,14 @@ Your service must be navigable and usable no matter how someone uses it (without
 * 2.2.2 Give people a way to stop content that updates frequently, blinks or scrolls automatically. [More about 2.2.2](/all.html#2-2-2-pause-stop-hide-a)
 
 #### Guideline 2.3: Do not cause seizures
-* 2.3.1 Do not use content that flashes more than three times a second. [More about 2.3.1](/all.html#2-3-1-three-flashes-or-below-a)
+* 2.3.1 Do not use content that flashes more than three times a second. [More about 2.3.1](/all.html#2-3-1-three-flashes-or-below-threshold-a)
 
 #### Guideline 2.4: Provide ways to help people navigate and find content
 * 2.4.1 Give people who do not use a mouse a way to move to the start of the main content. [More about 2.4.1](/all.html#2-4-1-bypass-blocks-a)
-* 2.4.2 Give every page a unique and helpful title that indicates the purpose of the page. [More about 2.4.2](/all.html#2-4-2-page-title-a)
+* 2.4.2 Give every page a unique and helpful title that indicates the purpose of the page. [More about 2.4.2](/all.html#2-4-2-page-titled-a)
 * 2.4.3 Make sure that things receive focus in an order that makes sense. [More about 2.4.3](/all.html#2-4-3-focus-order-a)
 * 2.4.4 Make sure the purpose of a link is obvious from its link text, or its link text in association with nearby content. [More about 2.4.4](/all.html#2-4-4-link-purpose-in-context-a)
-* 2.4.5 Unless a page is a step in a process, give people different ways of finding content (like searching or browsing links). [More about 2.4.5](/all.html#2-4-5-multiple-ways)
+* 2.4.5 Unless a page is a step in a process, give people different ways of finding content (like searching or browsing links). [More about 2.4.5](/all.html#2-4-5-multiple-ways-aa)
 * 2.4.6 Provide headings and form labels that will help people find content and complete tasks. [More about 2.4.6](/all.html#2-4-6-headings-and-labels-aa)
 * 2.4.7 Make sure that people using a keyboard to navigate can always see where they are on a page. [More about 2.4.7](/all.html#2-4-7-focus-visible-aa)
 
@@ -169,7 +169,7 @@ Your service must make information understandable, and make it easy for people t
 
 #### Guideline 3.1: Make text readable and understandable
 * 3.1.1 Identify the language that the content is written in. [More about 3.1.1](/all.html#3-1-1-language-of-page-a)
-* 3.1.2 Identify any changes in the default written language of the content. [More about 3.1.2](/all.html#3-1-2-language-of-parts-a)
+* 3.1.2 Identify any changes in the default written language of the content. [More about 3.1.2](/all.html#3-1-2-language-of-parts-aa)
 
 #### Guideline 3.2: Make things appear and behave in consistent ways
 * 3.2.1 Do not cause surprising things to happen (like opening a new page), when someone focuses on something. [More about 3.2.1](/all.html#3-2-1-on-focus-a)
@@ -181,7 +181,7 @@ Your service must make information understandable, and make it easy for people t
 * 3.3.1 When someone makes a mistake, provide an error message and make it obvious where the mistake was made. [More about 3.3.1](/all.html#3-3-1-error-identification-a)
 * 3.3.2 Provide form labels to make it clear what information is expected, and optionally provide extra hints to help people avoid mistakes. [More about 3.3.2](/all.html#3-3-2-labels-or-instructions-a)
 * 3.3.3 When someone makes a mistake give them suggestions on how to correct it, but do not offer suggestions that will have a negative impact on security. [More about 3.3.3](/all.html#3-3-3-error-suggestion-aa)
-* 3.4.4 Give people a way to review and check the information they have entered, and to correct any mistakes they have made. [More about 3.4.4](/all.html#3-3-4-error-prevention-legal-financial-data-a)
+* 3.4.4 Give people a way to review and check the information they have entered, and to correct any mistakes they have made. [More about 3.4.4](/all.html#3-3-4-error-prevention-legal-financial-data-aa)
 
 ### Principle 4: Robust
 


### PR DESCRIPTION
This PR:
- Adds links from the Checklist page back to the relevant section of the "All requirements" page, as discussed with the CDDO accessibility capability team
- Fixes some links that were previously broken on the Index page
- Updates the titles of two pages to match Web Content Accessibility Guidelines more closely
- Fixes a couple of small typos

I've tested the links locally on both the Checklist and Index pages.