### PR TITLE
Add write permission to the GitHub build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   # A really basic check to see if this builds okay.
+  permissions:
+    contents: write
   only-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   # A really basic check to see if this builds okay.
-  permissions:
-    contents: write
   only-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
The [build and deploy to GitHub Pages was failing](https://github.com/alphagov/wcag-primer/actions/runs/5974049669/job/16207470186) and this change has been proposed as a possible fix based on [this example](https://github.com/peaceiris/actions-gh-pages#getting-started).