### PR TITLE
Fix text errors and broken links

### DIFF
--- a/source/documentation/2.3.1.md
+++ b/source/documentation/2.3.1.md
@@ -1,4 +1,4 @@
-#### [2.3.1 Three flashes or below (A)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html)
+#### [2.3.1 Three flashes or below threshold (A)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html)
 
 A page must not contain content that flashes more than three times a second. This ensures that people with conditions like photosensitive Epilepsy are protected from harmful seizures.
 

--- a/source/documentation/2.4.2.md
+++ b/source/documentation/2.4.2.md
@@ -1,4 +1,4 @@
-#### [2.4.2 Page title (A)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html)
+#### [2.4.2 Page titled (A)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html)
 
 Each page must have a unique title that indicates its topic or purpose. This ensures that people with cognitive disabilities can quickly orientate themselves within the service and identify the purpose of the page without interpreting its entire contents.
 

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -2,7 +2,7 @@
 
 This document will help you get up to speed with WCAG 2.1 quickly and avoid common mistakes people make when creating or updating web content. You will find this really helpful if you design, build or create web content.
 
-WCAG 2.1 is the standard used by EN 301 549, the European procurement rules, and you need to pass these success criteria to comply with the UK Public Sector Bodies (Websites and Mobile Applications) Accessibility Regulations 2018.
+WCAG 2.1 is the standard used by the UK public sector, and you need to pass these success criteria to comply with the UK Public Sector Bodies (Websites and Mobile Applications) Accessibility Regulations 2018.
 
 See Gov.uk for more on how to [Make your public sector website or app accessible](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps)
 
@@ -28,11 +28,11 @@ WCAG 2.1 also helps us think about the different ways people use the web:
 * By using speech recognition to use the web with voice commands and dictation
 
 ## How does it relate to WCAG 2.0?
-WCAG 2.1 is built on 2.0. So content that passes  WCAG 2.1 will also also pass WCAG 2.0.
+WCAG 2.1 is built on 2.0. So content that passes  WCAG 2.1 will also pass WCAG 2.0.
 
 
 ## New things in WCAG 2.1:
-WCAG 2.1 extends WCAG 2.0 by adding new success criteria, definitions, and guidelines to organize the additions. There are some additions to the conformance section.
+WCAG 2.1 extends WCAG 2.0 by adding new success criteria, definitions, and guidelines to organise the additions. There are some additions to the conformance section.
 
 ### New Success Criteria
 
@@ -79,7 +79,7 @@ Each of these responsive page ‘versions’ needs to pass (or have an alternati
 
 ## WCAG 2.1 architecture
 
-WCAG 2.1 has twelve guidelines, grouped into four principles. The principle are that content must be:
+WCAG 2.1 has twelve guidelines, grouped into four principles. The principles are that content must be:
 
 * Perceivable
 * Operable
@@ -107,7 +107,7 @@ Your service must present information in ways people can recognise and use, no m
 
 #### Guideline 1.2: Provide alternatives for time-based media
 * 1.2.1 Provide a text description for video content that has no audio, or a transcript for audio content that has no video, and make sure the description and transcript serve the same purpose as the original content. [More about 1.2.1](all.html#1-2-1-audio-only-and-video-only-a)
-* 1.2.2 Provide real-time captions for video content that has audio, and make sure the captions include all dialogue and important sound-effects. [More about 1.2.2](/all.html#1-2-2-captions-a)
+* 1.2.2 Provide real-time captions for video content that has audio, and make sure the captions include all dialogue and important sound-effects. [More about 1.2.2](/all.html#1-2-2-captions-prerecorded-a)
 * 1.2.3 Provide a text description or a transcript for video content that has audio, and make sure the description or transcript serves the same purpose as the original content. [More about 1.2.3](/all.html#1-2-3-audio-description-or-media-alternative-a)
 * 1.2.4 Provide real-time captions for live video content that has audio, and make sure the captions include all dialogue and important sound-effects. [More about 1.2.4](/all.html#1-2-4-captions-live-aa)
 * 1.2.5 Provide audio description for video content, and make sure the description includes all important activity that takes place on-screen. [More about 1.2.5](/all.html#1-2-5-audio-description-pre-recorded-aa)
@@ -116,8 +116,8 @@ Your service must present information in ways people can recognise and use, no m
 * 1.3.1 Use elements like headings, lists and tables to properly convey the structure of content. [More about 1.3.1](/all.html#1-3-1-info-and-relationships-a)
 * 1.3.2 Make sure content can always be read in a logical order even when stylesheets are disabled. [More about 1.3.2](/all.html#1-3-2-meaningful-sequence-a)
 * 1.3.3 Do not use colour, size, shape, sound or location as the only way to convey instructions. [More about 1.3.3](/all.html#1-3-3-sensory-characteristics-a)
-* 1.3.4 [New] Make sure a page view is not locked to either horizontal or vertical views only, unless this is essential. [More about 1.3.4](/all.html#1-3-4-orientation-aa)
-* 1.3.5 [New] In forms that collect information <strong>about the user</strong> add HTML autocomplete attributes to identify the purpose of the input. [More about 1.3.5](/all.html#1-3-5-input-purpose-aa)
+* 1.3.4 [New] Make sure a page view is not locked to either horizontal or vertical views only, unless this is essential. [More about 1.3.4](/all.html#1-3-4-orientation-a)
+* 1.3.5 [New] In forms that collect information <strong>about the user</strong> add HTML autocomplete attributes to identify the purpose of the input. [More about 1.3.5](/all.html#1-3-5-identify-input-purpose-aa)
 
 #### Guideline 1.4: Make content easy for people to see and hear
 * 1.4.1 Do not use colour as the only way to convey information of any kind. [More about 1.4.1](/all.html#1-4-1-use-of-colour-a)
@@ -128,7 +128,7 @@ Your service must present information in ways people can recognise and use, no m
 * 1.4.10 [New] Make sure content will reflow to a single column when zoomed and not produce scrolling in both directions. [More about 1.4.10](/all.html#1-4-10-reflow-aa)
 * 1.4.11 [New] Make sure sight impaired users can see important controls and understand graphics. [More about 1.4.11](/all.html#1-4-11-non-text-contrast-aa)
 * 1.4.12 [New] Make sure users can modify text line height, letter or word spacing. [More about 1.4.12](/all.html#1-4-12-text-spacing-aa)
-* 1.4.13 <strong>[New]</strong> Provide a way to control how people can interact with or dismiss any ‘extra’ content that becomes visible. [More about 1.4.13](/all.html#1-4-13-content-on-hover-or-focus-aa)
+* 1.4.13 [New] Provide a way to control how people can interact with or dismiss any ‘extra’ content that becomes visible. [More about 1.4.13](/all.html#1-4-13-content-on-hover-or-focus-aa)
 
 
 
@@ -146,14 +146,14 @@ Your service must be navigable and usable no matter how someone uses it (without
 * 2.2.2 Give people a way to stop content that updates frequently, blinks or scrolls automatically. [More about 2.2.2](/all.html#2-2-2-pause-stop-hide-a)
 
 #### Guideline 2.3: Do not cause seizures
-* 2.3.1 Do not use content that flashes more than three times a second. [More about 2.3.1](/all.html#2-3-1-three-flashes-or-below-a)
+* 2.3.1 Do not use content that flashes more than three times a second. [More about 2.3.1](/all.html#2-3-1-three-flashes-or-below-threshold-a)
 
 #### Guideline 2.4: Provide ways to help people navigate and find content
 * 2.4.1 Give people who do not use a mouse a way to move to the start of the main content. [More about 2.4.1](/all.html#2-4-1-bypass-blocks-a)
-* 2.4.2 Give every page a unique and helpful title that indicates the purpose of the page. [More about 2.4.2](/all.html#2-4-2-page-title-a)
+* 2.4.2 Give every page a unique and helpful title that indicates the purpose of the page. [More about 2.4.2](/all.html#2-4-2-page-titled-a)
 * 2.4.3 Make sure that things receive focus in an order that makes sense. [More about 2.4.3](/all.html#2-4-3-focus-order-a)
 * 2.4.4 Make sure the purpose of a link is obvious from its link text, or its link text in association with nearby content. [More about 2.4.4](/all.html#2-4-4-link-purpose-in-context-a)
-* 2.4.5 Unless a page is a step in a process, give people different ways of finding content (like searching or browsing links). [More about 2.4.5](/all.html#2-4-5-multiple-ways)
+* 2.4.5 Unless a page is a step in a process, give people different ways of finding content (like searching or browsing links). [More about 2.4.5](/all.html#2-4-5-multiple-ways-aa)
 * 2.4.6 Provide headings and form labels that will help people find content and complete tasks. [More about 2.4.6](/all.html#2-4-6-headings-and-labels-aa)
 * 2.4.7 Make sure that people using a keyboard to navigate can always see where they are on a page. [More about 2.4.7](/all.html#2-4-7-focus-visible-aa)
 
@@ -169,7 +169,7 @@ Your service must make information understandable, and make it easy for people t
 
 #### Guideline 3.1: Make text readable and understandable
 * 3.1.1 Identify the language that the content is written in. [More about 3.1.1](/all.html#3-1-1-language-of-page-a)
-* 3.1.2 Identify any changes in the default written language of the content. [More about 3.1.2](/all.html#3-1-2-language-of-parts-a)
+* 3.1.2 Identify any changes in the default written language of the content. [More about 3.1.2](/all.html#3-1-2-language-of-parts-aa)
 
 #### Guideline 3.2: Make things appear and behave in consistent ways
 * 3.2.1 Do not cause surprising things to happen (like opening a new page), when someone focuses on something. [More about 3.2.1](/all.html#3-2-1-on-focus-a)
@@ -181,7 +181,7 @@ Your service must make information understandable, and make it easy for people t
 * 3.3.1 When someone makes a mistake, provide an error message and make it obvious where the mistake was made. [More about 3.3.1](/all.html#3-3-1-error-identification-a)
 * 3.3.2 Provide form labels to make it clear what information is expected, and optionally provide extra hints to help people avoid mistakes. [More about 3.3.2](/all.html#3-3-2-labels-or-instructions-a)
 * 3.3.3 When someone makes a mistake give them suggestions on how to correct it, but do not offer suggestions that will have a negative impact on security. [More about 3.3.3](/all.html#3-3-3-error-suggestion-aa)
-* 3.4.4 Give people a way to review and check the information they have entered, and to correct any mistakes they have made. [More about 3.4.4](/all.html#3-3-4-error-prevention-legal-financial-data-a)
+* 3.4.4 Give people a way to review and check the information they have entered, and to correct any mistakes they have made. [More about 3.4.4](/all.html#3-3-4-error-prevention-legal-financial-data-aa)
 
 ### Principle 4: Robust
 


### PR DESCRIPTION
This PR fixes text errors and broken links which were originally identified in #77 . They have been split into a separate pull request in order to keep unrelated changes separate.

I have tested all of the links on `index.md` and they work.

There is no change to the overall meaning of the content except to remove one reference to the European standard EN 301 549 which is no longer part of UK legislation.