### PR TITLE
Add AAA clarification

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -60,7 +60,7 @@ The following Success Criteria are new in WCAG 2.1:
 * 2.5.6 Concurrent Input Mechanisms (AAA)
 * 4.1.3 Status Messages (AA)
 
-This primer will only focus on new A and AA success criteria.
+This primer only focuses on the level A and AA success criteria. [All AAA criteria can be viewed on the W3C website](https://www.w3.org/WAI/WCAG22/quickref/?versions=2.2&currentsidebar=%23col_customize&levels=a%2Caa). They are not included in this primer because the Public Sector Bodies Accessibility Regulations do not require AAA compliance.
 
 #### Numbering changes in WCAG 2.1
 


### PR DESCRIPTION
This PR replaces #17 , originally suggested by @BNewing , to add clarification on why AAA criteria were not included in the primer. That change was previously approved although I've tweaked it slightly to bring it up to date.

As #17 has become out of date with tricky conflicts, it will be closed.
