### PR TITLE
Various small jobs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (C) 2024 Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/config.rb
+++ b/config.rb
@@ -2,6 +2,9 @@ require 'govuk_tech_docs'
 
 GovukTechDocs.configure(self)
 
+# use custom layout file
+set :layout, 'custom'
+
 # use relative paths for links and sources
 activate :relative_assets
 set :relative_links, true

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -2,7 +2,7 @@
 host:
 
 # Header-related options
-show_govuk_logo: true
+show_govuk_logo: false
 service_name: WCAG 2.1 Primer
 service_link: /index.html
 phase: alpha

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -38,3 +38,7 @@ max_toc_heading_level: 4
 
 # Prevent robots from indexing (e.g. whilst in development)
 prevent_indexing: true
+
+# Show GitHub source/issue/repo links at the bottom of each page
+show_contribution_banner: true
+github_repo: alphagov/wcag-primer

--- a/source/layouts/custom.erb
+++ b/source/layouts/custom.erb
@@ -1,0 +1,5 @@
+<% wrap_layout :layout do %>
+  <%= partial 'partials/internal-banner' %>
+
+  <%= yield %>
+<% end %>

--- a/source/partials/_internal-banner.html.erb
+++ b/source/partials/_internal-banner.html.erb
@@ -1,0 +1,3 @@
+<div class="app-internal-banner">
+  <p><strong>The WCAG Primer is intended for use by the UK cross government accessibility community.</strong></p>
+</div>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -2,3 +2,13 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica",
   sans-serif;
 
 @import "govuk_tech_docs";
+
+.app-internal-banner {
+  margin: govuk-spacing(5) 0;
+  padding-bottom: govuk-spacing(2);
+  border-bottom: 1px solid govuk-colour("mid-grey");
+
+  p {
+    margin: 0;
+  }
+}

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,4 @@
+$govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica",
+  sans-serif;
+
 @import "govuk_tech_docs";


### PR DESCRIPTION
Various small jobs from the update task list.

- Removes GOV.UK brand elements (crown icon, logotype, Transport typeface).
- Enables GitHub source, issue reporting and repo links at the bottom of all pages.
- Adds an 'internal use only' banner to the top of all pages.
  - Was a little unsure of how to word this one. Internal use to whom? Civil servants? HM Government? 
- Adds MIT license to the repository.
  - It seems to be typical to put the OGL on the content pages and MIT in the repo, I think because OGL only covers the content and MIT only covers the code. That's an assumption on my part, though.