### PR TITLE
Remove survey link

### DIFF
--- a/source/partials/_internal-banner.html.erb
+++ b/source/partials/_internal-banner.html.erb
@@ -1,3 +1,3 @@
 <div class="app-internal-banner">
-  <p><strong>The WCAG Primer is intended for use by the UK cross government accessibility community. <a href="https://docs.google.com/forms/d/e/1FAIpQLSeYXJVDj2D8WvrZsq0BgrGzhuvxjnZWm1jNzcABEr0bTjKqXg/viewform">Complete our survey here</a>.</strong></p>
+  <p><strong>The WCAG Primer is intended for use by the UK cross government accessibility community.</strong></p>
 </div>


### PR DESCRIPTION
The WCAG Primer survey has since closed so we would like to remove the survey link.
