### PR TITLE
Require GOV.UK frontend

### DIFF
--- a/source/javascripts/govuk_frontend.js
+++ b/source/javascripts/govuk_frontend.js
@@ -1,0 +1,1 @@
+//= require govuk_frontend_all


### PR DESCRIPTION
This PR adds a requirement for GOV.UK Frontend, in the same way as the [GDS Way](https://github.com/alphagov/gds-way/blob/main/source/javascripts/govuk_frontend.js). This was previously missing based on @shabana-ali 's investigations into #121 .

It fixes #121 by introducing a collapsible menu, meaning that page content can be viewed at all zoom levels up to 500% on a standard laptop screen.

I've tested it locally in Chrome and Safari, and it works for me.