### PR TITLE
Update to GOV.UK Tech Docs 4.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.8.6)
+    activesupport (7.0.8.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -19,7 +19,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.23.10)
+    commonmarker (0.23.11)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -34,8 +34,8 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.3.4)
     contracts (0.16.1)
-    csv (3.3.0)
-    dotenv (3.1.4)
+    csv (3.3.1)
+    dotenv (3.1.6)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -45,10 +45,10 @@ GEM
     fast_blank (1.0.1)
     fastimage (2.3.1)
     ffi (1.17.0)
-    google-protobuf (4.28.3)
+    google-protobuf (4.29.1)
       bigdecimal
       rake (>= 13)
-    govuk_tech_docs (4.1.0)
+    govuk_tech_docs (4.1.1)
       autoprefixer-rails (~> 10.2)
       base64
       bigdecimal
@@ -78,8 +78,8 @@ GEM
     http_parser.rb (0.8.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -137,11 +137,11 @@ GEM
     middleman-syntax (3.4.0)
       middleman-core (>= 3.2)
       rouge (~> 3.2)
-    mini_portile2 (2.8.7)
-    minitest (5.25.1)
+    mini_portile2 (2.8.8)
+    minitest (5.25.4)
     multi_json (1.15.0)
-    mutex_m (0.2.0)
-    nokogiri (1.16.7)
+    mutex_m (0.3.0)
+    nokogiri (1.17.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     openapi3_parser (0.9.2)
@@ -163,10 +163,10 @@ GEM
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     redcarpet (3.6.0)
-    rexml (3.3.9)
+    rexml (3.4.0)
     rouge (3.30.0)
     sass (3.4.25)
-    sass-embedded (1.80.6)
+    sass-embedded (1.83.0)
       google-protobuf (~> 4.28)
       rake (>= 13)
     sassc (2.4.0)
@@ -188,7 +188,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
-    webrick (1.9.0)
+    webrick (1.9.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Ran a `bundle update` to use the latest version of Tech Docs, 4.1.1. Tested locally and it works for me.