### PR TITLE
Remove unnecessary references to WCAG 2.1

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -3,7 +3,7 @@ host:
 
 # Header-related options
 show_govuk_logo: false
-service_name: WCAG 2.1 Primer
+service_name: WCAG Primer
 service_link: /index.html
 phase: Alpha
 

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Accessibility statement for the WCAG 2.1 Primer
+title: Accessibility statement for the WCAG Primer
 last_reviewed_on: 2020-09-04
 review_in: 6 months
 hide_in_navigation: true
@@ -7,7 +7,7 @@ hide_in_navigation: true
 
 # <%= current_page.data.title %>
 
-This accessibility statement applies to the WCAG 2.1 Primer at [https://alphagov.github.io/wcag-primer/](https://alphagov.github.io/wcag-primer/).
+This accessibility statement applies to the WCAG Primer at [https://alphagov.github.io/wcag-primer/](https://alphagov.github.io/wcag-primer/).
 
 This website is run by the Accessibility team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
 

--- a/source/all.html.md.erb
+++ b/source/all.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: All WCAG 2.1 A and AA Success Criteria
+title: All WCAG A and AA Success Criteria
 ---
 
 # <%= current_page.data.title %>

--- a/source/code.html.md.erb
+++ b/source/code.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Code related WCAG 2.1 A and AA Success Criteria
+title: Code related WCAG A and AA Success Criteria
 ---
 
 # <%= current_page.data.title %>

--- a/source/content.html.md.erb
+++ b/source/content.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Content related WCAG 2.1 A and AA Success Criteria
+title: Content related WCAG A and AA Success Criteria
 ---
 
 # <%= current_page.data.title %>

--- a/source/design.html.md.erb
+++ b/source/design.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Design related WCAG 2.1 A and AA Success Criteria
+title: Design related WCAG A and AA Success Criteria
 ---
 
 # <%= current_page.data.title %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -2,9 +2,9 @@
 title: Home
 ---
 
-# WCAG 2.1 Getting started
+# WCAG Getting started
 
-This document will help you get up to speed with WCAG 2.1 quickly and avoid common mistakes people make when creating or updating web content. You will find this really helpful if you design, build or create web content.
+This document will help you get up to speed with the Web Content Accessibility Guidelines (WCAG) quickly and avoid common mistakes people make when creating or updating web content. You will find this really helpful if you design, build or create web content. It currently includes criteria from WCAG 2.1 but there is work underway to update it to WCAG 2.2.
 
 WCAG 2.1 is the standard used by the UK public sector, and you need to pass these success criteria to comply with the UK Public Sector Bodies (Websites and Mobile Applications) Accessibility Regulations 2018.
 
@@ -32,10 +32,11 @@ WCAG 2.1 also helps us think about the different ways people use the web:
 * By using speech recognition to use the web with voice commands and dictation
 
 ## How does it relate to WCAG 2.0?
-WCAG 2.1 is built on 2.0. So content that passes  WCAG 2.1 will also pass WCAG 2.0.
 
+WCAG 2.1 is built on 2.0. So content that passes WCAG 2.1 will also pass WCAG 2.0.
 
 ## New things in WCAG 2.1:
+
 WCAG 2.1 extends WCAG 2.0 by adding new success criteria, definitions, and guidelines to organise the additions. There are some additions to the conformance section.
 
 ### New Success Criteria
@@ -98,7 +99,7 @@ Each guideline has a number of Success Criteria (SC). Each SC has a conformance 
 
 Public sector websites, documents and mobile apps that meet WCAG 2.1 Level A and AA Success Criteria and publish an accessibility statement will comply with the [new accessibility regulations for public sector websites and apps](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps).
 
-## WCAG 2.1 overview
+## WCAG overview
 
 Here is a short description of the principles, guidelines and success criteria you must meet.
 
@@ -194,9 +195,9 @@ Your service must work with different browsers and assistive technologies in use
 * 4.1.2 Make sure the code of each page enables assistive technologies to discover the purpose of every feature, the way that feature is identified, and the state it is currently in. [More about 4.1.2](/sc/4.1.2.html)
 * 4.1.3 [New] Make sure status messages are shown in a way that assistive technologies understand without receiving focus. [More about 4.1.3](/sc/4.1.3.html)
 
-## How to meet the WCAG 2.1
+## How to meet WCAG
 
-Use our primer to find out more about the success criteria to understand how to meet WCAG 2.1.
+Use our primer to find out more about the success criteria to understand how to meet WCAG.
 
 View [all success criteria](/all.html), or view those that are related to [content](/content.html), [design](/design.html) or [code](/code.html).
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -6,7 +6,7 @@ title: Home
 
 This document will help you get up to speed with the Web Content Accessibility Guidelines (WCAG) quickly and avoid common mistakes people make when creating or updating web content. You will find this really helpful if you design, build or create web content. It currently includes criteria from WCAG 2.1 but there is work underway to update it to WCAG 2.2.
 
-WCAG 2.1 is the standard used by the UK public sector, and you need to pass these success criteria to comply with the UK Public Sector Bodies (Websites and Mobile Applications) Accessibility Regulations 2018.
+WCAG is the standard used by the UK public sector, and you need to pass these success criteria to comply with the UK Public Sector Bodies (Websites and Mobile Applications) Accessibility Regulations 2018.
 
 See Gov.uk for more on how to [Make your public sector website or app accessible](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps)
 
@@ -74,6 +74,7 @@ Also remember that this having them at the end does not relate to its level at a
 WCAG 2.1 uses the same conformance or passing model as WCAG 2.0 with some minor changes.  2.1 is designed to be compatible with the earlier version, so sites that conform/pass WCAG 2.1 also conform to WCAG 2.0.
 
 #### Conformance/Passing addition and changes
+
 There are some minor conformance or passing additions to note, firstly about ‘page variations’, relating to responsive page design which will be relevant if you have a responsive site.
 
 ##### Page variations


### PR DESCRIPTION
This pull request removes unnecessary references to Web Content Accessibility Guidelines (WCAG) version 2.1, where the WCAG version is irrelevant to the page. These references were in:

* the service name
* the titles of several pages, including the home page
* the main heading on the home page
* some of the text 

I've retained some references to 2.1 where that version is specific to the text, and it's still important to signpost users that it's not the latest version.

I've also added a note at the start of the home page to say that we're working on an update to WCAG 2.2.