### PR TITLE
Update accessibility statement for 2025

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -17,7 +17,7 @@ header_links:
   Checklist: /checklist.html
   Community: /community.html
 footer_links:
-  Accessibility: /accessibility.html
+  Accessibility statement: /accessibility.html
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: false

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,86 +1,57 @@
 ---
 title: Accessibility statement for the WCAG Primer
-last_reviewed_on: 2020-09-04
-review_in: 6 months
 hide_in_navigation: true
 ---
 
 # <%= current_page.data.title %>
 
-This accessibility statement applies to the WCAG Primer at [https://alphagov.github.io/wcag-primer/](https://alphagov.github.io/wcag-primer/).
+Government Digital Service is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
-This website is run by the Accessibility team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
-
-+ change colours, contrast levels and fonts
-+ zoom in up to 300% without problems
-+ navigate most of the website using just a keyboard
-+ navigate most of the website using speech recognition software
-+ listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
-
-We’ve also made the website text as simple as possible to understand.
-
-AbilityNet has advice on [making your device easier to use](https://mcmw.abilitynet.org.uk/) if you have a disability.
+This accessibility statement applies to the Web Content Accessibility Guidelines (WCAG) Primer on [alphagov.github.io/wcag-primer](./).
 
 ## How accessible this website is
 
-We know some parts of this website are not fully accessible.
+Although we believe this website meets the legal standard, we know some parts of this website are not fully accessible. In particular:
 
-There are issues caused by our Technical Documentation Template.
+* users of speech recognition software may find it difficult to scroll through the side menu
+* some content such as the Crown Copyright image may not display well when using a high contrast mode
 
-## Feedback and contact information
-
-If you need any part of this service in a different format like large print, audio recording or braille, email [accessibility@digital.cabinet-office.gov.uk](mailto:accessibility@digital.cabinet-office.gov.uk).
-
-We’ll aim to get back to you within 3 working days.
-
-## Reporting accessibility problems with this website
-
-We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [accessibility@digital.cabinet-office.gov.uk](mailto:accessibility@digital.cabinet-office.gov.uk).
-
-## Enforcement procedure
-
-The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
-(the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
-
-## Technical information about this website’s accessibility
-
-GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+We have identified some other issues which we believe fall outside of WCAG AA. These are listed on our [issues page](https://github.com/alphagov/wcag-primer/issues) and we are working to fix them.
 
 ## Compliance status
 
-This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
-
-### Non-accessible content
-
-The content listed below is non-accessible for the following reasons.
-
-#### Non-compliance with the accessibility regulations
-
-Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
-
-## How we tested this website
-
-We last tested this website for accessibility issues in September 2020.
-
-We used manual and automated tests to look for issues such as:
-
-- lack of keyboard accessibility
-- link text that’s not descriptive
-- non-unique or non-hierarchical headings
-- italics, bold and block capital formatting
-- inaccessible formatting in general
-- inaccessible language
-- inaccessible diagrams or images
-- lack of colour contrast for text, important graphics and controls
-- images not having meaningful alt text
-- problems when using assistive technologies such as screen readers and screen magnifiers
-
-## What we’re doing to improve accessibility
-
-We plan to fix the accessibility issues with the Technical Documentation Template by the end of March 2021.
+This website is fully compliant with the WCAG version 2.2 AA standard.
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 10 September 2020. It was last reviewed on 31 December 2020.
+This statement was prepared on 10 September 2020. It was last reviewed on 25 July 2025.
 
-This website was last tested in September 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a selection of the website's pages.
+A manual and automated accessibility audit was carried out in January 2025, testing the following representative pages for all WCAG 2.2 AA criteria:
+
+* [WCAG Primer home page (Getting started)](/)
+* [Accessibility statement for the WCAG Primer](/accessibility.html)
+* [3.1.1 Language of Page (A)](/sc/3.1.1.html)
+* [4.1.2 Name, Role, Value (A)](/sc/4.1.2.html)
+* [Community](/community.html)
+
+Testing was carried out on both Mac and Windows machines. The tools we used for testing included:
+
+* Chrome and Safari browsers
+* VoiceOver on Mac
+* VoiceControl on Mac
+* JAWS on Windows
+* NVDA on Windows
+* Dragon on Windows
+* Windows High Contrast Mode
+
+This audit identified several issues. All WCAG AA issues from this audit were fixed, and a further, brief manual and automated accessibility check was carried out in June 2025.
+
+## Feedback and contact information
+
+If you have any feedback, or experience any accessibility issues with the WCAG Primer, then please email us on [accessibility-guide@digital.cabinet-office.gov.uk](mailto:accessibility-guide@digital.cabinet-office.gov.uk).
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations').
+
+If you're not happy with how we respond to your complaint, contact the [Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).


### PR DESCRIPTION
This PR updates the WCAG Primer accessibility statement based on our recent testing. It also updates the name of the link in the footer from "Accessibility" to "Accessibility statement". Tested locally and works for me.