### PR TITLE
Add `figure` and `figcaption` styles

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -3,6 +3,7 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica",
 
 @import "govuk_tech_docs";
 
+// Banner at the top of the page
 .app-internal-banner {
   margin: govuk-spacing(5) 0;
   padding-bottom: govuk-spacing(2);
@@ -10,5 +11,19 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica",
 
   p {
     margin: 0;
+  }
+}
+
+// Style figure/figcaption elements
+.technical-documentation > figure {
+  margin: 0;
+  border: 1px solid govuk-colour("dark-grey");
+  line-height: 0; // needed to remove extra whitespace beneath images
+  @include govuk-responsive-margin(5, $direction: bottom);
+
+  figcaption {
+    @include govuk-font(16);
+    @include govuk-responsive-padding(2);
+    border-top: 1px solid govuk-colour("dark-grey");
   }
 }


### PR DESCRIPTION
Add styles for `figure` and `figcaption` elements, as per the comment here: https://github.com/alphagov/wcag-primer/pull/150#issuecomment-3149844408 

## Changes
- Added styles for `figure` and `figcaption` elements within the main content area. 

## Screenshot
<img width="1572" height="910" alt="Screenshot of prose with a figure in the middle. The figure has a thin grey border surrounding it and its caption, with an additional border between the image and caption." src="https://github.com/user-attachments/assets/210fe518-e408-4e6b-a21e-d91625e1cd26" />

## Thoughts
- Images with black text on a white background, as on the example above, are pretty difficult to separate from the surrounding text at a glance. Adding a border helps make them more distinct.
- Adding a border also helps tie together narrow images that have wide captions too. (In a print design world the captions would probably be capped to the same width as the image, but that's easier said than done in a web context!)
- Making the caption a smaller font size helps visually separate them from normal prose. I realise this may not be ideal for readability, but it seems a common enough pattern for figures to be expected.