### PR TITLE
Remove Alpha tag

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,7 +5,6 @@ host:
 show_govuk_logo: false
 service_name: WCAG Primer
 service_link: /index.html
-phase: Alpha
 
 # Links to show on right-hand-side of header
 header_links:


### PR DESCRIPTION
This PR removes the Alpha tag from the WCAG Primer header, as we've decided as a group that it is unnecessary (it's not a service on gov.uk).

I've tested it locally at a range of zoom levels in Chrome and Safari, and it looks fine.