### PR TITLE
Fix blockquote format for 4.1.2 Name Role Value

### DIFF
--- a/source/sc/4.1.2.html.md.erb
+++ b/source/sc/4.1.2.html.md.erb
@@ -6,7 +6,7 @@ title: 4.1.2 Name, Role, Value (A)
 
 ## What WCAG says:
 
-"For all user interface components … the name and role can be programmatically determined; states, properties, and values that can be set by the user can be programmatically set; and notification of changes to these items is available to … assistive technologies."
+> For all user interface components … the name and role can be programmatically determined; states, properties, and values that can be set by the user can be programmatically set; and notification of changes to these items is available to … assistive technologies.
 
 [Understanding 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value)
 


### PR DESCRIPTION
The format under "What WCAG says" on the recently rewritten 4.1.2 Name Role Value page was inconsistent, and didn't include the blockquote format we've used on other new pages.

This PR fixes that to make it consistent. It looks fine on my local machine.