### PR TITLE
Remove banner stating the intended audience

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -2,9 +2,6 @@ require 'govuk_tech_docs'
 
 GovukTechDocs.configure(self)
 
-# use custom layout file
-set :layout, 'custom'
-
 # use relative paths for links and sources
 activate :relative_assets
 set :relative_links, true

--- a/source/layouts/custom.erb
+++ b/source/layouts/custom.erb
@@ -1,5 +1,0 @@
-<% wrap_layout :layout do %>
-  <%= partial 'partials/internal-banner' %>
-
-  <%= yield %>
-<% end %>

--- a/source/partials/_internal-banner.html.erb
+++ b/source/partials/_internal-banner.html.erb
@@ -1,3 +1,0 @@
-<div class="app-internal-banner">
-  <p><strong>The WCAG Primer is intended for use by the UK cross government accessibility community.</strong></p>
-</div>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -3,17 +3,6 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica",
 
 @import "govuk_tech_docs";
 
-// Banner at the top of the page
-.app-internal-banner {
-  margin: govuk-spacing(5) 0;
-  padding-bottom: govuk-spacing(2);
-  border-bottom: 1px solid govuk-colour("mid-grey");
-
-  p {
-    margin: 0;
-  }
-}
-
 // Style figure/figcaption elements
 .technical-documentation > figure {
   margin: 0;


### PR DESCRIPTION
This pull request reverses an [earlier commit to add a banner](https://github.com/alphagov/wcag-primer/commit/c5afa04740b5d5a83f13dfda4261ca97fd796f4a) stating "The WCAG Primer is intended for use by the UK cross government accessibility community."

The working group has decided to remove this banner as it creates noise on screen, slows users from reading the main heading and doesn't add value. Instead, we will signal the intended audience in the main body of the Home page. This will be done in a separate pull request.

Merging this PR also fixes #135 by removing the banner.

I've tested it on my local machine at a few different screen sizes and it looks fine:

<img width="1254" height="250" alt="WCAG Primer home page with the main heading and body content appearing straight away rather than underneath a banner" src="https://github.com/user-attachments/assets/a051148a-eb29-4696-aa44-bc8c700e598f" />