### PR TITLE
Enable indexing by search engines

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -39,7 +39,7 @@ max_toc_heading_level: 4
 enable_anchored_headings: false
 
 # Prevent robots from indexing (e.g. whilst in development)
-prevent_indexing: true
+prevent_indexing: false
 
 # Show GitHub source/issue/repo links at the bottom of each page
 show_contribution_banner: true


### PR DESCRIPTION
DO NOT MERGE UNTIL RENAMING IS COMPLETE.

This pull request allows the guide to be indexed by search engines. We intend to activate this once the renaming steps are complete - these are covered in #171 .

While it can't be tested locally, I've done a quick click around a few pages to ensure nothing is obviously broken - it looks fine.