### PR TITLE
Update test guide links for recently published pages

### DIFF
--- a/source/sc/1.3.1.html.md.erb
+++ b/source/sc/1.3.1.html.md.erb
@@ -31,7 +31,7 @@ Use your browser's developer tools, assistive technologies or a plugin such as W
 
 If HTML cannot be used to convey all visual relationships then ARIA (Accessible Rich Internet Applications) code may also be used. However, standard HTML should be used wherever possible.
 
-[How to test in detail for 1.3.1 Info and Relationships](https://github.com/alphagov/wcag-primer/wiki/1.3.1)
+[How to test in detail for 1.3.1 Info and Relationships](https://github.com/alphagov/guide-to-wcag/wiki/1.3.1)
 
 ## Good examples
 

--- a/source/sc/1.3.4.html.md.erb
+++ b/source/sc/1.3.4.html.md.erb
@@ -24,7 +24,7 @@ For users with dexterity impairments who fix a mobile device or tablet in one po
 
 Using a device with an orientation sensor, such as a tablet or smartphone, make sure that content remains readable and user interface controls remain usable in both portrait and landscape. You should not be prompted to change the orientation.
 
-[How to test in detail for 1.3.4 Orientation](https://github.com/alphagov/wcag-primer/wiki/1.3.4) 
+[How to test in detail for 1.3.4 Orientation](https://github.com/alphagov/guide-to-wcag/wiki/1.3.4) 
 
 ## Good example
 

--- a/source/sc/1.4.3.html.md.erb
+++ b/source/sc/1.4.3.html.md.erb
@@ -49,7 +49,7 @@ The following automated checkers can often detect contrast issues by comparing t
 
 Colours are usually written using a hex code format. For example, pure blue is `#0000FF`.
 
-[How to test in detail for 1.4.3 Contrast (Minimum)](https://github.com/alphagov/wcag-primer/wiki/1.4.3)
+[How to test in detail for 1.4.3 Contrast (Minimum)](https://github.com/alphagov/guide-to-wcag/wiki/1.4.3)
 
 ## Good examples
 

--- a/source/sc/2.4.11.html.md.erb
+++ b/source/sc/2.4.11.html.md.erb
@@ -28,7 +28,7 @@ Look for scenarios where a focused item could end up behind something else, such
 
 It's OK if focused components can be made visible without moving the focus, for example by pressing the Escape key to dismiss a menu, or using the arrow keys to bring it into view.
 
-[How to test in detail for 2.4.11 Focus Not Obscured (Minimum)](https://github.com/alphagov/wcag-primer/wiki/2.4.11)
+[How to test in detail for 2.4.11 Focus Not Obscured (Minimum)](https://github.com/alphagov/guide-to-wcag/wiki/2.4.11)
 
 ## Good examples
 

--- a/source/sc/2.5.8.html.md.erb
+++ b/source/sc/2.5.8.html.md.erb
@@ -45,7 +45,7 @@ If you need to test manually, you will need to measure the pixels between the ce
 * inspecting the elements in your browser's developer tools, to measure the size and margins of each component
 * taking a screenshot and using an image editing tool to count pixels
 
-[How to test in detail for 2.5.8 Target Size (Minimum)](https://github.com/alphagov/wcag-primer/wiki/2.5.8)
+[How to test in detail for 2.5.8 Target Size (Minimum)](https://github.com/alphagov/guide-to-wcag/wiki/2.5.8)
 
 ## Good example
 

--- a/source/sc/3.3.8.html.md.erb
+++ b/source/sc/3.3.8.html.md.erb
@@ -36,7 +36,7 @@ It's OK if any of the following are true:
 * a test involves identifying images, audio or video that the user has already provided
 * help is provided to complete a test - such as hints
 
-[How to test in detail for 3.3.8 Accessible Authentication](https://github.com/alphagov/wcag-primer/wiki/3.3.8)
+[How to test in detail for 3.3.8 Accessible Authentication](https://github.com/alphagov/guide-to-wcag/wiki/3.3.8)
 
 ## Good example
 


### PR DESCRIPTION
This PR updates 6 links from the main guide to the test guide. This is needed because the repository has been renamed, moving the wiki URL where the test guide is hosted. I've tested them locally and the links all work.