### PR TITLE
Reformat success criterion links

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -82,11 +82,13 @@ Find out more about [what's new in WCAG 2.2](https://www.w3.org/WAI/standards-gu
 
 ## WCAG overview
 
-Here is a short description of the principles, guidelines and success criteria you must meet.
+Here is a short description of the principles, guidelines and success criteria you must meet. This is a list of all the level A and level AA criteria.
+
+You can find out more about each criterion by following the links in each section.
 
 ### Principle 1: Perceivable
 
-Your service must present information in ways people can recognise and use, no matter how they consume content (by touch, sound or sight for example)
+Your service must present information in ways people can recognise and use, no matter how they read content (by touch, sound or sight for example).
 
 #### Guideline 1.1: Provide text alternatives
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -89,97 +89,110 @@ Here is a short description of the principles, guidelines and success criteria y
 Your service must present information in ways people can recognise and use, no matter how they consume content (by touch, sound or sight for example)
 
 #### Guideline 1.1: Provide text alternatives
-* 1.1.1 Provide a text description for images, and make sure the description serves the same purpose as the image. [More about 1.1.1](/sc/1.1.1.html)
+
+* [1.1.1 Non-text Content (A)](/sc/1.1.1.html): Provide a text description for images, and make sure the description serves the same purpose as the image.
 
 #### Guideline 1.2: Provide alternatives for time-based media
-* 1.2.1 Provide a text description for video content that has no audio, or a transcript for audio content that has no video, and make sure the description and transcript serve the same purpose as the original content. [More about 1.2.1](/sc/1.2.1.html)
-* 1.2.2 Provide real-time captions for video content that has audio, and make sure the captions include all dialogue and important sound-effects. [More about 1.2.2](/sc/1.2.2.html)
-* 1.2.3 Provide a text description or a transcript for video content that has audio, and make sure the description or transcript serves the same purpose as the original content. [More about 1.2.3](/sc/1.2.3.html)
-* 1.2.4 Provide real-time captions for live video content that has audio, and make sure the captions include all dialogue and important sound-effects. [More about 1.2.4](/sc/1.2.4.html)
-* 1.2.5 Provide audio description for video content, and make sure the description includes all important activity that takes place on-screen. [More about 1.2.5](/sc/1.2.5.html)
+
+* [1.2.1 Audio-only and Video-only (A)](/sc/1.2.1.html): Provide a text description for video content that has no audio, or a transcript for audio content that has no video, and make sure the description and transcript serve the same purpose as the original content.
+* [1.2.2 Captions (Prerecorded) (A)](/sc/1.2.2.html): Provide real-time captions for video content that has audio, and make sure the captions include all dialogue and important sound-effects.
+* [1.2.3 Audio Description or Media Alternative (A)](/sc/1.2.3.html): Provide a text description or a transcript for video content that has audio, and make sure the description or transcript serves the same purpose as the original content.
+* [1.2.4 Captions (Live) (AA)](/sc/1.2.4.html): Provide real-time captions for live video content that has audio, and make sure the captions include all dialogue and important sound-effects.
+* [1.2.5 Audio Description (Prerecorded) (AA)](/sc/1.2.5.html): Provide audio description for video content, and make sure the description includes all important activity that takes place on-screen.
 
 #### Guideline 1.3: Create content that can be presented in different ways
-* 1.3.1 Use elements like headings, lists and tables to properly convey the structure of content. [More about 1.3.1](/sc/1.3.1.html)
-* 1.3.2 Make sure content can always be read in a logical order even when stylesheets are disabled. [More about 1.3.2](/sc/1.3.2.html)
-* 1.3.3 Do not use colour, size, shape, sound or location as the only way to convey instructions. [More about 1.3.3](/sc/1.3.3.html)
-* 1.3.4 Make sure a page view is not locked to either horizontal or vertical views only, unless this is essential. [More about 1.3.4](/sc/1.3.4.html)
-* 1.3.5 In forms that collect information <strong>about the user</strong> add HTML autocomplete attributes to identify the purpose of the input. [More about 1.3.5](/sc/1.3.5.html)
+
+* [1.3.1 Info and Relationships (A)](/sc/1.3.1.html): Use elements like headings, lists and tables to properly convey the structure of content.
+* [1.3.2 Meaningful Sequence (A)](/sc/1.3.2.html): Make sure content can always be read in a logical order even when stylesheets are disabled.
+* [1.3.3 Sensory Characteristics (A)](/sc/1.3.3.html): Do not use colour, size, shape, sound or location as the only way to convey instructions.
+* [1.3.4 Orientation (A)](/sc/1.3.4.html): Make sure a page view is not locked to either horizontal or vertical views only, unless this is essential.
+* [1.3.5 Identify Input Purpose (AA)](/sc/1.3.5.html): In forms that collect information <strong>about the user</strong> add HTML autocomplete attributes to identify the purpose of the input.
 
 #### Guideline 1.4: Make content easy for people to see and hear
-* 1.4.1 Do not use colour as the only way to convey information of any kind. [More about 1.4.1](/sc/1.4.1.html)
-* 1.4.2 Give people a way to stop audio content if it plays automatically and lasts longer than three seconds, or give them a way to change the volume without changing their system settings. [More about 1.4.2](/sc/1.4.2.html)
-* 1.4.3 Make sure that the colour of text contrasts clearly against its background colour. [More about 1.4.3](/sc/1.4.3.html)
-* 1.4.4 Make sure it is possible to complete all tasks when text is resized up to 200% in the browser. [More about 1.4.4](/sc/1.4.4.html)
-* 1.4.5 Do not use images that contain text. [More about 1.4.5](/sc/1.4.5.html)
-* 1.4.10 Make sure content will reflow to a single column when zoomed and not produce scrolling in both directions. [More about 1.4.10](/sc/1.4.10.html)
-* 1.4.11 Make sure sight impaired users can see important controls and understand graphics. [More about 1.4.11](/sc/1.4.11.html)
-* 1.4.12 Make sure users can modify text line height, letter or word spacing. [More about 1.4.12](/sc/1.4.12.html)
-* 1.4.13 Provide a way to control how people can interact with or dismiss any ‘extra’ content that becomes visible. [More about 1.4.13](/sc/1.4.13.html)
+
+* [1.4.1 Use of Colour (A)](/sc/1.4.1.html): Do not use colour as the only way to convey information of any kind.
+* [1.4.2 Audio Control (A)](/sc/1.4.2.html): Give people a way to stop audio content if it plays automatically and lasts longer than three seconds, or give them a way to change the volume without changing their system settings.
+* [1.4.3 Contrast (Minimum) (AA)](/sc/1.4.3.html): Make sure that the colour of text contrasts clearly against its background colour.
+* [1.4.4 Resize Text (AA)](/sc/1.4.4.html): Make sure it is possible to complete all tasks when text is resized up to 200% in the browser.
+* [1.4.5 Images of Text (AA)](/sc/1.4.5.html): Do not use images that contain text.
+* [1.4.10 Reflow (AA)](/sc/1.4.10.html): Make sure content will reflow to a single column when zoomed and not produce scrolling in both directions.
+* [1.4.11 Non-text Contrast (AA)](/sc/1.4.11.html): Make sure sight impaired users can see important controls and understand graphics.
+* [1.4.12 Text Spacing (AA)](/sc/1.4.12.html): Make sure users can modify text line height, letter or word spacing.
+* [1.4.13 Content on Hover or Focus (AA)](/sc/1.4.13.html): Provide a way to control how people can interact with or dismiss any ‘extra’ content that becomes visible.
 
 ### Principle 2: Operable
 
 Your service must be navigable and usable no matter how someone uses it (without a mouse, with voice commands, or with a screen magnifier for example).
 
 #### Guideline 2.1: Make functionality work with a keyboard
-* 2.1.1 Make sure every task can be completed using just a keyboard. [More about 2.1.1](/sc/2.1.1.html)
-* 2.1.2 Make sure that keyboard users do not get stuck when navigating through content. [More about 2.1.2](/sc/2.1.2.html)
-* 2.1.4 Provide a way to switch off or remap keyboard shortcuts. [More about 2.1.4](/sc/2.1.4.html)
+
+* [2.1.1 Keyboard (A)](/sc/2.1.1.html): Make sure every task can be completed using just a keyboard.
+* [2.1.2 No Keyboard Trap (A)](/sc/2.1.2.html): Make sure that keyboard users do not get stuck when navigating through content.
+* [2.1.4 Character Key Shortcuts (A)](/sc/2.1.4.html): Provide a way to switch off or remap keyboard shortcuts.
 
 #### Guideline 2.2: Give people enough time to read and use content
-* 2.2.1 Give people a way to turn off or extend time limits. [More about 2.2.1](/sc/2.2.1.html)
-* 2.2.2 Give people a way to stop content that updates frequently, blinks or scrolls automatically. [More about 2.2.2](/sc/2.2.2.html)
+
+* [2.2.1 Timing Adjustable (A)](/sc/2.2.1.html): Give people a way to turn off or extend time limits.
+* [2.2.2 Pause, Stop, Hide (A)](/sc/2.2.2.html): Give people a way to stop content that updates frequently, blinks or scrolls automatically.
 
 #### Guideline 2.3: Do not cause seizures
-* 2.3.1 Do not use content that flashes more than three times a second. [More about 2.3.1](/sc/2.3.1.html)
+
+* [2.3.1 Three Flashes or Below Threshold (A)](/sc/2.3.1.html): Do not use content that flashes more than three times a second.
 
 #### Guideline 2.4: Provide ways to help people navigate and find content
-* 2.4.1 Give people who do not use a mouse a way to move to the start of the main content. [More about 2.4.1](/sc/2.4.1.html)
-* 2.4.2 Give every page a unique and helpful title that indicates the purpose of the page. [More about 2.4.2](/sc/2.4.2.html)
-* 2.4.3 Make sure that things receive focus in an order that makes sense. [More about 2.4.3](/sc/2.4.3.html)
-* 2.4.4 Make sure the purpose of a link is obvious from its link text, or its link text in association with nearby content. [More about 2.4.4](/sc/2.4.4.html)
-* 2.4.5 Unless a page is a step in a process, give people different ways of finding content (like searching or browsing links). [More about 2.4.5](/sc/2.4.5.html)
-* 2.4.6 Provide headings and form labels that will help people find content and complete tasks. [More about 2.4.6](/sc/2.4.6.html)
-* 2.4.7 Make sure that people using a keyboard to navigate can always see where they are on a page. [More about 2.4.7](/sc/2.4.7.html)
-* 2.4.11 [New] Make sure that people can always see any components that have keyboard focus. [More about 2.4.11](/sc/2.4.11.html)
+
+* [2.4.1 Bypass Blocks (A)](/sc/2.4.1.html): Give people who do not use a mouse a way to move to the start of the main content.
+* [2.4.2 Page Titled (A)](/sc/2.4.2.html): Give every page a unique and helpful title that indicates the purpose of the page.
+* [2.4.3 Focus Order (A)](/sc/2.4.3.html): Make sure that things receive focus in an order that makes sense.
+* [2.4.4 Link Purpose (In Context) (A)](/sc/2.4.4.html): Make sure the purpose of a link is obvious from its link text, or its link text in association with nearby content.
+* [2.4.5 Multiple Ways (AA)](/sc/2.4.5.html): Unless a page is a step in a process, give people different ways of finding content (like searching or browsing links).
+* [2.4.6 Headings and Labels (AA)](/sc/2.4.6.html): Provide headings and form labels that will help people find content and complete tasks.
+* [2.4.7 Focus Visible (AA)](/sc/2.4.7.html): Make sure that people using a keyboard to navigate can always see where they are on a page.
+* [2.4.11 Focus Not Obscured (Minimum) (AA)](/sc/2.4.11.html): [New] Make sure that people can always see any components that have keyboard focus.
 
 #### Guideline 2.5: Make functionality easy to use through various inputs beyond keyboard
-* 2.5.1 Do not require complex gestures to do things. [More about 2.5.1](/sc/2.5.1.html)
-* 2.5.2 Do not have controls or user interface components that fire as soon as they are touched. [More about 2.5.2](/sc/2.5.2.html)
-* 2.5.3 Make sure that for user interface components with a visible label the accessible name matches. [More about 2.5.3](/sc/2.5.3.html)
-* 2.5.4 Make sure functionality can not only be activated by shaking or tilting the device. [More about 2.5.4](/sc/2.5.4.html)
-* 2.5.8 [New] Make sure controls, like buttons or links, are big enough or spaced far enough apart. [More about 2.5.8](/sc/2.5.8.html)
+
+* [2.5.1 Pointer Gestures (A)](/sc/2.5.1.html): Do not require complex gestures to do things. 
+* [2.5.2 Pointer Cancellation (A)](/sc/2.5.2.html): Do not have controls or user interface components that fire as soon as they are touched.
+* [2.5.3 Label in Name (A)](/sc/2.5.3.html): Make sure that for user interface components with a visible label the accessible name matches.
+* [2.5.4 Motion Actuation (A)](/sc/2.5.4.html): Make sure functionality can not only be activated by shaking or tilting the device.
+* [2.5.8 Target Size (Minimum) (AA)](/sc/2.5.8.html): [New] Make sure controls, like buttons or links, are big enough or spaced far enough apart.
 
 ### Principle 3: Understandable
 
 Your service must make information understandable, and make it easy for people to understand how to complete tasks.
 
 #### Guideline 3.1: Make text readable and understandable
-* 3.1.1 Identify the language that the content is written in. [More about 3.1.1](/sc/3.1.1.html)
-* 3.1.2 Identify any changes in the default written language of the content. [More about 3.1.2](/sc/3.1.2.html)
+
+* [3.1.1 Language of Page (A)](/sc/3.1.1.html): Identify the language that the content is written in.
+* [3.1.2 Language of Parts (AA)](/sc/3.1.2.html): Identify any changes in the default written language of the content.
 
 #### Guideline 3.2: Make things appear and behave in consistent ways
-* 3.2.1 Do not cause surprising things to happen (like opening a new page), when someone focuses on something. [More about 3.2.1](/sc/3.2.1.html)
-* 3.2.2 Do not cause surprising things to happen when someone interacts with content (like scrolling through a set of options). [More about 3.2.2](/sc/3.2.2.html)
-* 3.2.3 Make sure that ways to find and navigate content (like search) look and behave the same way when they are used in multiple places. [More about 3.2.3](/sc/3.2.3.html)
-* 3.2.4 Make sure that features look and behave the same way when they are used in multiple places. [More about 3.2.4](/sc/3.2.4.html)
-* 3.2.6 [New] Show help options in a consistent place across pages. [More about 3.2.6](/sc/3.2.6.html)
+
+* [3.2.1 On Focus (A)](/sc/3.2.1.html): Do not cause surprising things to happen (like opening a new page), when someone focuses on something.
+* [3.2.2 On Input (A)](/sc/3.2.2.html): Do not cause surprising things to happen when someone interacts with content (like scrolling through a set of options).
+* [3.2.3 Consistent Navigation (AA)](/sc/3.2.3.html): Make sure that ways to find and navigate content (like search) look and behave the same way when they are used in multiple places.
+* [3.2.4 Consistent Identification (AA)](/sc/3.2.4.html): Make sure that features look and behave the same way when they are used in multiple places.
+* [3.2.6 Consistent Help (A)](/sc/3.2.6.html): [New] Show help options in a consistent place across pages.
 
 #### Guideline 3.3: Help people avoid and correct mistakes
-* 3.3.1 When someone makes a mistake, provide an error message and make it obvious where the mistake was made. [More about 3.3.1](/sc/3.3.1.html)
-* 3.3.2 Provide form labels to make it clear what information is expected, and optionally provide extra hints to help people avoid mistakes. [More about 3.3.2](/sc/3.3.2.html)
-* 3.3.3 When someone makes a mistake give them suggestions on how to correct it, but do not offer suggestions that will have a negative impact on security. [More about 3.3.3](/sc/3.3.3.html)
-* 3.3.4 Give people a way to review and check the information they have entered, and to correct any mistakes they have made. [More about 3.3.4](/sc/3.3.4.html)
-* 3.3.7 [New] Help people avoid having to re-enter information. [More about 3.3.7](/sc/3.3.7.html)
-* 3.3.8 [New] Make it as easy as possible to sign in - don't make people remember, solve or transcribe something. [More about 3.3.8](/sc/3.3.8.html)
+
+* [3.3.1 Error Identification (A)](/sc/3.3.1.html): When someone makes a mistake, provide an error message and make it obvious where the mistake was made.
+* [3.3.2 Labels or Instructions (A)](/sc/3.3.2.html): Provide form labels to make it clear what information is expected, and optionally provide extra hints to help people avoid mistakes.
+* [3.3.3 Error Suggestion (AA)](/sc/3.3.3.html): When someone makes a mistake give them suggestions on how to correct it, but do not offer suggestions that will have a negative impact on security.
+* [3.3.4 Error Prevention (Legal, Financial, Data) (AA)](/sc/3.3.4.html): Give people a way to review and check the information they have entered, and to correct any mistakes they have made.
+* [3.3.7 Redundant Entry (A)](/sc/3.3.7.html): [New] Help people avoid having to re-enter information.
+* [3.3.8 Accessible Authentication (Minimum) (AA)](/sc/3.3.8.html): [New] Make it as easy as possible to sign in - don't make people remember, solve or transcribe something.
 
 ### Principle 4: Robust
 
 Your service must work with different browsers and assistive technologies in use now, and use technologies in ways that will make your service usable with the browsers and assistive technologies of the future.
 
 #### Guideline 4.1: Make content compatible with different browsers and assistive technologies
-* 4.1.1 Make sure the code of each page does not contain errors that will have a negative impact on the way browsers and assistive technologies work together. [More about 4.1.1](/sc/4.1.1.html)
-* 4.1.2 Make sure the code of each page enables assistive technologies to discover the purpose of every feature, the way that feature is identified, and the state it is currently in. [More about 4.1.2](/sc/4.1.2.html)
-* 4.1.3 Make sure status messages are shown in a way that assistive technologies understand without receiving focus. [More about 4.1.3](/sc/4.1.3.html)
+
+* [4.1.1 Parsing (A)](/sc/4.1.1.html): Make sure the code of each page does not contain errors that will have a negative impact on the way browsers and assistive technologies work together.
+* [4.1.2 Name, Role, Value (A)](/sc/4.1.2.html): Make sure the code of each page enables assistive technologies to discover the purpose of every feature, the way that feature is identified, and the state it is currently in.
+* [4.1.3 Status Messages (AA)](/sc/4.1.3.html): Make sure status messages are shown in a way that assistive technologies understand without receiving focus.
 
 ## How to meet WCAG
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -69,12 +69,12 @@ It also includes all the criteria from previous versions of WCAG, apart from 4.1
 
 The new A or AA criteria for WCAG 2.2 are:
 
-* 2.4.11 Focus Not Obscured (Minimum) (AA) 
+* [2.4.11 Focus Not Obscured (Minimum) (AA)](/sc/2.4.11.html)
 * 2.5.7 Dragging Movements (AA)
-* 2.5.8 Target Size (Minimum) (AA)
-* 3.2.6 Consistent Help (A)
-* 3.3.7 Redundant Entry (A)
-* 3.3.8 Accessible Authentication (Minimum) (AA)
+* [2.5.8 Target Size (Minimum) (AA)](/sc/2.5.8.html)
+* [3.2.6 Consistent Help (A)](/sc/3.2.6.html)
+* [3.3.7 Redundant Entry (A)](/sc/3.3.7.html)
+* [3.3.8 Accessible Authentication (Minimum) (AA)](/sc/3.3.8.html)
 
 If your website or app meets WCAG 2.2, it also meets versions 2.1 and 2.0.
 

--- a/source/sc/1.3.1.html.md.erb
+++ b/source/sc/1.3.1.html.md.erb
@@ -158,9 +158,9 @@ In general, this success criterion fails when the code does not match the visual
 
 This success criterion is closely related to several others. In some cases, more than one of these criteria might fail at the same time:
 
-* [1.1.1 Non-text Content](1.1.1.html) covers images and symbols having appropriate alternative text.
-* [1.3.2 Meaningful Sequence](1.3.2.html) makes sure that the reading order of content is logical.
-* [2.4.6 Headings and Labels](2.4.6.html) makes sure that labels are descriptive.
-* [2.5.3 Label in Name](2.5.3.html) makes sure that a component's name (in the code) contains the visible label.
-* [3.3.2 Labels or Instructions](3.3.2.html) makes sure that elements have labels, but does not require them to be associated with each other.
-* [4.1.2 Name, Role, Value](4.1.2.html) interactive elements having appropriate names, roles and values, regardless of how they appear visually.
+* [1.1.1 Non-text Content (A)](1.1.1.html) covers images and symbols having appropriate alternative text.
+* [1.3.2 Meaningful Sequence (A)](1.3.2.html) makes sure that the reading order of content is logical.
+* [2.4.6 Headings and Labels (AA)](2.4.6.html) makes sure that labels are descriptive.
+* [2.5.3 Label in Name (A)](2.5.3.html) makes sure that a component's name (in the code) contains the visible label.
+* [3.3.2 Labels or Instructions (A)](3.3.2.html) makes sure that elements have labels, but does not require them to be associated with each other.
+* [4.1.2 Name, Role, Value (A)](4.1.2.html) interactive elements having appropriate names, roles and values, regardless of how they appear visually.

--- a/source/sc/1.3.4.html.md.erb
+++ b/source/sc/1.3.4.html.md.erb
@@ -50,7 +50,7 @@ This fails because the app's layout does not adjust to match the device's orient
 
 ## Related success criteria
 
-To pass this success criterion, it's only important that the user is not forced to use a specific orientation. Ensuring that layouts adapt to changing orientations is partially covered by [1.4.10 Reflow](1.4.10.html).
+To pass this success criterion, it's only important that the user is not forced to use a specific orientation. Ensuring that layouts adapt to changing orientations is partially covered by [1.4.10 Reflow (AA)](1.4.10.html).
 
 ## Useful resources
 

--- a/source/sc/1.4.1.html.md.erb
+++ b/source/sc/1.4.1.html.md.erb
@@ -56,5 +56,5 @@ In general, the following examples fail:
 
 ## Related success criteria
 
-* [1.4.3 Contrast (Minimum)](1.4.3.html) makes sure that text has enough contrast, regardless of whether it relies on colour to distinguish it.
-* [1.4.11 Non-text Contrast](1.4.11.html) makes sure that components have enough contrast to be visible, regardless of whether they are distinguishable using colour. This can apply to icons, form fields or keyboard focus indicators.
+* [1.4.3 Contrast (Minimum) (AA)](1.4.3.html) makes sure that text has enough contrast, regardless of whether it relies on colour to distinguish it.
+* [1.4.11 Non-text Contrast (AA)](1.4.11.html) makes sure that components have enough contrast to be visible, regardless of whether they are distinguishable using colour. This can apply to icons, form fields or keyboard focus indicators.

--- a/source/sc/1.4.11.html.md.erb
+++ b/source/sc/1.4.11.html.md.erb
@@ -60,9 +60,9 @@ An orange focus indicator on a white page has insufficient contrast to be able t
 
 ## Related success criteria
 
-* [1.4.1 Use of Colour](1.4.1.html) covers elements being identified by colour alone.
-* [1.4.3 Contrast (Minimum)](1.4.3.html) covers the contrast of text.
-* [2.4.7 Focus Visible](2.4.7.html) covers focus indicators being visible, but 1.4.11 Non-text Contrast determines how visible they should be.
+* [1.4.1 Use of Colour (A)](1.4.1.html) covers elements being identified by colour alone.
+* [1.4.3 Contrast (Minimum) (AA)](1.4.3.html) covers the contrast of text.
+* [2.4.7 Focus Visible (AA)](2.4.7.html) covers focus indicators being visible, but 1.4.11 Non-text Contrast determines how visible they should be.
 
 ## Useful links
 

--- a/source/sc/1.4.3.html.md.erb
+++ b/source/sc/1.4.3.html.md.erb
@@ -89,6 +89,6 @@ This blue link text does not have enough contrast when it has keyboard focus - t
 
 This success criterion only relates to the contrast of text.
 
-* [1.4.1 Use of Colour](1.4.1.html) requires that colour is not the only way to convey information.
-* [1.4.6 Contrast (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced) encourages you to use a minimum contrast ratio of 7:1 to meet level AAA.
-* [1.4.11 Non-text Contrast](1.4.11.html) covers the contrast of anything meaningful other than text.
+* [1.4.1 Use of Colour (A)](1.4.1.html) requires that colour is not the only way to convey information.
+* [1.4.6 Contrast (Enhanced) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced) encourages you to use a minimum contrast ratio of 7:1 to meet level AAA.
+* [1.4.11 Non-text Contrast (AA)](1.4.11.html) covers the contrast of anything meaningful other than text.

--- a/source/sc/1.4.5.html.md.erb
+++ b/source/sc/1.4.5.html.md.erb
@@ -70,6 +70,6 @@ In this case, the text in the image cannot be enlarged, changed or read by assis
 
 ## Related success criteria
 
-* [1.1.1 Non-text Content](1.1.1.html) covers images having a text alternative.
-* [1.4.3 Contrast (Minimum)](1.4.3.html) requires that text in images has sufficient contrast to the background.
-* [1.4.9 Images of Text (No Exception)](https://www.w3.org/WAI/WCAG22/Understanding/images-of-text-no-exception) is a more strict AAA guideline with more restrictions.
+* [1.1.1 Non-text Content (A)](1.1.1.html) covers images having a text alternative.
+* [1.4.3 Contrast (Minimum) (AA)](1.4.3.html) requires that text in images has sufficient contrast to the background.
+* [1.4.9 Images of Text (No Exception) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/images-of-text-no-exception) is a more strict AAA guideline with more restrictions.

--- a/source/sc/2.1.1.html.md.erb
+++ b/source/sc/2.1.1.html.md.erb
@@ -67,9 +67,9 @@ While custom buttons can be made to be accessible, it takes extra effort to ensu
 
 ## Related success criteria
 
-* [2.1.2 No Keyboard Trap](2.1.2.html) requires that the keyboard never gets stuck in one part of a page.
-* [2.4.1 Bypass Blocks](2.4.1.html) requires that there’s a way to skip past repeated content.
-* [2.4.3 Focus Order](2.4.3.html) requires that keyboard focus is in a logical order.
-* [2.4.7 Focus Visible](2.4.7.html) requires that you can see where keyboard focus currently is.
-* [2.4.11 Focus Not Obscured](2.4.11.html) requires that focused components are not hidden by other components.
-* [3.2.1 On Focus](3.2.1.html) and [3.2.2 On Input](3.2.2.html) require that no disorienting changes happen when focusing on, or updating a user interface component.
+* [2.1.2 No Keyboard Trap (A)](2.1.2.html) requires that the keyboard never gets stuck in one part of a page.
+* [2.4.1 Bypass Blocks (A)](2.4.1.html) requires that there’s a way to skip past repeated content.
+* [2.4.3 Focus Order (A)](2.4.3.html) requires that keyboard focus is in a logical order.
+* [2.4.7 Focus Visible (AA)](2.4.7.html) requires that you can see where keyboard focus currently is.
+* [2.4.11 Focus Not Obscured (Minimum) (AA)](2.4.11.html) requires that focused components are not hidden by other components.
+* [3.2.1 On Focus (A)](3.2.1.html) and [3.2.2 On Input](3.2.2.html) require that no disorienting changes happen when focusing on, or updating a user interface component.

--- a/source/sc/2.4.1.html.md.erb
+++ b/source/sc/2.4.1.html.md.erb
@@ -49,4 +49,4 @@ This link moves the visual and keyboard focus to the main content area, skipping
 
 ## Related success criteria
 
-[2.4.3 Focus Order](2.4.3.html) ensures that the focus order around the page is logical, to help users navigate predictably using a keyboard.
+[2.4.3 Focus Order (A)](2.4.3.html) ensures that the focus order around the page is logical, to help users navigate predictably using a keyboard.

--- a/source/sc/2.4.11.html.md.erb
+++ b/source/sc/2.4.11.html.md.erb
@@ -58,6 +58,6 @@ This could be resolved by either restricting keyboard focus to the cookie dialog
 
 ## Related success criteria
 
-[2.4.7 Focus Visible](2.4.7.html) relates to focus indicators being visible. If a component has no visible focus indicator at all, it fails Focus Visible. If it has a visible focus indicator, but the component is hidden behind something else, it fails Focus Not Obscured.
+[2.4.7 Focus Visible (AA)](2.4.7.html) relates to focus indicators being visible. If a component has no visible focus indicator at all, it fails Focus Visible. If it has a visible focus indicator, but the component is hidden behind something else, it fails Focus Not Obscured.
 
-The stricter AAA criterion, explained on [Understanding 2.4.12 Focus Not Obscured (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-enhanced) encourages you not to hide components at all when they are focused.
+The stricter AAA criterion, explained on [Understanding 2.4.12 Focus Not Obscured (Enhanced) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-enhanced) encourages you not to hide components at all when they are focused.

--- a/source/sc/2.4.2.html.md.erb
+++ b/source/sc/2.4.2.html.md.erb
@@ -85,6 +85,6 @@ While “friendly” filenames can help with understanding, a document's propert
 
 ## Related success criteria
 
-* [2.4.4 Link Purpose (in Context)](2.4.4.html) requires that links have text which makes sense in context.
-* [2.4.5 Multiple Ways](2.4.5.html) requires there to be at least two ways of finding a page. If one of those methods is search, then accurate page titles are important to help meet this.
-* [2.4.6 Headings and Labels](2.4.6.html) requires that headings within pages, and component labels are descriptive.
+* [2.4.4 Link Purpose (In Context) (A)](2.4.4.html) requires that links have text which makes sense in context.
+* [2.4.5 Multiple Ways (AA)](2.4.5.html) requires there to be at least two ways of finding a page. If one of those methods is search, then accurate page titles are important to help meet this.
+* [2.4.6 Headings and Labels (AA)](2.4.6.html) requires that headings within pages, and component labels are descriptive.

--- a/source/sc/2.4.3.html.md.erb
+++ b/source/sc/2.4.3.html.md.erb
@@ -65,12 +65,12 @@ The following scenarios may also have an impact on focus order:
 
 ## Related success criteria
 
-* [1.3.2 Meaningful Sequence](1.3.2.html) relates to the reading order of all meaningful content on the page, not just focusable elements
-* [2.1.1 Keyboard](2.1.1.html) requires everything to work with a keyboard, regardless of whether the focus is in a logical order or not.
-* [2.4.7 Focus Visible](2.4.7.html) requires that keyboard focus is always visible, regardless of the order.
-* [2.4.11 Focus Not Obscured](2.4.11.html) requires that elements are not covered by something else on screen when they do receive focus.
-* [3.2.1 On Focus](3.2.1.html) requires focus to stay where it is when an element receives focus.
-* [3.2.2 On Input](3.2.2.html) requires focus to stay where it is when something interactive is changed, like a toggle switch.
+* [1.3.2 Meaningful Sequence (A)](1.3.2.html) relates to the reading order of all meaningful content on the page, not just focusable elements
+* [2.1.1 Keyboard (A)](2.1.1.html) requires everything to work with a keyboard, regardless of whether the focus is in a logical order or not.
+* [2.4.7 Focus Visible (AA)](2.4.7.html) requires that keyboard focus is always visible, regardless of the order.
+* [2.4.11 Focus Not Obscured (Minimum) (AA)](2.4.11.html) requires that elements are not covered by something else on screen when they do receive focus.
+* [3.2.1 On Focus (A)](3.2.1.html) requires focus to stay where it is when an element receives focus.
+* [3.2.2 On Input (A)](3.2.2.html) requires focus to stay where it is when something interactive is changed, like a toggle switch.
 
 ## Useful resources
 

--- a/source/sc/2.4.4.html.md.erb
+++ b/source/sc/2.4.4.html.md.erb
@@ -77,10 +77,10 @@ Either the link text could be made self-explanatory, or extra visually hidden te
 
 This success criterion specifically relates to links being descriptive.
 
-* [1.1.1 Non-text Content](1.1.1.html) relates to images having alternative text. If a link only contains an image which fails Non-text Content, it is likely to fail 2.4.4 Link Purpose too.
-* [2.4.6 Headings and Labels](2.4.6.html) relates to other components having descriptive labels, not just links.
-* [2.5.3 Label in Name](2.5.3.html) requires that the accessible name includes any text that's presented visually.
-* [4.1.2 Name, Role, Value](4.1.2.html) requires that links also have an appropriate role.
+* [1.1.1 Non-text Content (A)](1.1.1.html) relates to images having alternative text. If a link only contains an image which fails Non-text Content, it is likely to fail 2.4.4 Link Purpose too.
+* [2.4.6 Headings and Labels (AA)](2.4.6.html) relates to other components having descriptive labels, not just links.
+* [2.5.3 Label in Name (A)](2.5.3.html) requires that the accessible name includes any text that's presented visually.
+* [4.1.2 Name, Role, Value (A)](4.1.2.html) requires that links also have an appropriate role.
 
 ## Useful links
 

--- a/source/sc/2.4.5.html.md.erb
+++ b/source/sc/2.4.5.html.md.erb
@@ -58,5 +58,5 @@ Common mistakes include:
 
 ## Related success criteria
 
-* [2.4.2 Page Titled](2.4.2.html) helps to make it easier to find pages by making sure they have descriptive titles.
-* [3.2.3 Consistent Navigation](3.2.3.html) makes sure that navigation menus are always presented in a consistent order.
+* [2.4.2 Page Titled (A)](2.4.2.html) helps to make it easier to find pages by making sure they have descriptive titles.
+* [3.2.3 Consistent Navigation (AA)](3.2.3.html) makes sure that navigation menus are always presented in a consistent order.

--- a/source/sc/2.4.7.html.md.erb
+++ b/source/sc/2.4.7.html.md.erb
@@ -56,12 +56,12 @@ Some websites have focus styles turned off by default, using code such as `"outl
 
 This success criterion only requires that a focus indicator is visible without specifying how visible it should be. There are several other closely-related criteria:
 
-* [1.4.1 Use of Colour](1.4.1.html) requires there to be some way other than a change in colour to determine what has keyboard focus.
-* [1.4.3 Contrast](1.4.3.html) requires text to have enough contrast even when focussed.
-* [1.4.11 Non-text Contrast](1.4.11.html) requires that a focus indicator has a contrast ratio of at least 3:1 against surrounding pixels.
-* [2.1.1 Keyboard](2.1.1.html) requires everything to work with a keyboard, regardless of whether or not the focus is visible.
-* [2.4.3 Focus Order](2.4.3.html) requires elements to receive focus in a logical order.
-* [2.4.11 Focus Not Obscured](2.4.11.html) requires elements that would normally have visible focus not to be covered by something else on screen.
-* [3.2.1 On Focus](3.2.1.html) requires focus to stay where it is when an element receives focus.
+* [1.4.1 Use of Colour (A)](1.4.1.html) requires there to be some way other than a change in colour to determine what has keyboard focus.
+* [1.4.3 Contrast (Minimum) (AA)](1.4.3.html) requires text to have enough contrast even when focussed.
+* [1.4.11 Non-text Contrast (AA)](1.4.11.html) requires that a focus indicator has a contrast ratio of at least 3:1 against surrounding pixels.
+* [2.1.1 Keyboard (A)](2.1.1.html) requires everything to work with a keyboard, regardless of whether or not the focus is visible.
+* [2.4.3 Focus Order (A)](2.4.3.html) requires elements to receive focus in a logical order.
+* [2.4.11 Focus Not Obscured (Minimum) (AA)](2.4.11.html) requires elements that would normally have visible focus not to be covered by something else on screen.
+* [3.2.1 On Focus (A)](3.2.1.html) requires focus to stay where it is when an element receives focus.
 
-Also, [Understanding 2.4.13 Focus Appearance (level AAA)](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance) has more guidance on how visible a focus indicator should be.
+Also, [Understanding 2.4.13 Focus Appearance (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance) has more guidance on how visible a focus indicator should be.

--- a/source/sc/3.2.6.html.md.erb
+++ b/source/sc/3.2.6.html.md.erb
@@ -69,5 +69,5 @@ On every page that the "Chat to us" link appears, it needs to be in the same rel
 
 Consistent Help is at level A but overlaps closely with the following level AA criteria:
 
-* [3.2.3 Consistent Navigation](3.2.3.html) requires that repeated navigational elements (such as menu links) appear in the same relative order.
-* [3.2.4 Consistent Identification](3.2.4.html) requires that repeated functionality has consistent labels. For example, the same link should not be labelled "Help" on one page and "Support" on another.
+* [3.2.3 Consistent Navigation (AA)](3.2.3.html) requires that repeated navigational elements (such as menu links) appear in the same relative order.
+* [3.2.4 Consistent Identification (AA)](3.2.4.html) requires that repeated functionality has consistent labels. For example, the same link should not be labelled "Help" on one page and "Support" on another.

--- a/source/sc/3.3.4.html.md.erb
+++ b/source/sc/3.3.4.html.md.erb
@@ -10,15 +10,15 @@ When completion of a form causes a legal commitment, triggers a financial transa
 
 ## Requirements / What to do?
 
-*   When data is submitted leading to a legal commitment, financial transaction, or an update to personal data, an interim page, alert or status message is presented that allows the user to review, correct, and confirm the information they have entered.
+* When data is submitted leading to a legal commitment, financial transaction, or an update to personal data, an interim page, alert or status message is presented that allows the user to review, correct, and confirm the information they have entered.
 
 ## Common mistakes
 
-*   An online shop where order or personal details are not displayed so the user can confirm them or make changes.
+* An online shop where order or personal details are not displayed so the user can confirm them or make changes.
 
 ## Useful resources
 
-*   [Let the user review and correct information before submission](https://www.w3.org/WAI/WCAG21/Techniques/general/G98).
+* [Let the user review and correct information before submission](https://www.w3.org/WAI/WCAG21/Techniques/general/G98).
 * [Requesting confirmation to continue with selected action](https://www.w3.org/WAI/WCAG21/Techniques/general/G168)
 * [Validating user input](https://www.w3.org/WAI/tutorials/forms/validation/)
 

--- a/source/sc/3.3.7.html.md.erb
+++ b/source/sc/3.3.7.html.md.erb
@@ -62,5 +62,5 @@ In this example, a service is asking a user for a reference number that was alre
 
 ## Related success criteria
 
-* [3.3.4 Error Prevention (Legal, Financial, Data)](3.3.4.html) helps users to avoid errors by allowing them to confirm or correct information they have previously entered.
-* [3.3.8 Accessible Authentication](3.3.8.html) helps users to log in without having to re-type a password or code.
+* [3.3.4 Error Prevention (Legal, Financial, Data) (AA)](3.3.4.html) helps users to avoid errors by allowing them to confirm or correct information they have previously entered.
+* [3.3.8 Accessible Authentication (AA)](3.3.8.html) helps users to log in without having to re-type a password or code.

--- a/source/sc/3.3.8.html.md.erb
+++ b/source/sc/3.3.8.html.md.erb
@@ -76,8 +76,8 @@ This could be improved by replacing the question with an object recognition test
 
 ## Related success criteria
 
-* [3.3.7 Redundant Entry](3.3.7.html) aims to make it easier for users to re-enter information as part of a service.
-* To achieve AAA compliance and meet [3.3.9 Accessible Authentication (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced), you need to meet the AA criterion without relying on users recognising objects or content they've already provided.
+* [3.3.7 Redundant Entry (A)](3.3.7.html) aims to make it easier for users to re-enter information as part of a service.
+* To achieve AAA compliance and meet [3.3.9 Accessible Authentication (Enhanced) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced), you need to meet the AA criterion without relying on users recognising objects or content they've already provided.
 
 ## Useful resources
 

--- a/source/sc/4.1.2.html.md.erb
+++ b/source/sc/4.1.2.html.md.erb
@@ -101,6 +101,6 @@ To pass this success criterion, the name, role and value (or state) only need to
 
 Other criteria cover the need for interactive components to be descriptive (2.4.6 Headings and Labels) and presented visually (3.3.2 Labels or Instructions). 
 
-* [1.3.1 Info and Relationships](1.3.1.html) relates to visual and programmatic information being presented consistently. While there is an overlap, Info and Relationships is more concerned with the structure of a page, and covers non-interactive elements.
-* [2.4.6 Headings and Labels](2.4.6.html) requires that any accessible names are descriptive. Name, Role, Value only ensures that they exist.
-* [3.3.2 Labels or Instructions](3.3.2.html) requires that labels exist for all users.
+* [1.3.1 Info and Relationships (A)](1.3.1.html) relates to visual and programmatic information being presented consistently. While there is an overlap, Info and Relationships is more concerned with the structure of a page, and covers non-interactive elements.
+* [2.4.6 Headings and Labels (AA)](2.4.6.html) requires that any accessible names are descriptive. Name, Role, Value only ensures that they exist.
+* [3.3.2 Labels or Instructions (A)](3.3.2.html) requires that labels exist for all users.


### PR DESCRIPTION
This pull request reformats all internal links to success criterion pages to include the full name and level, for example:

[1.4.3 Contrast (Minimum) (A)](https://alphagov.github.io/guide-to-wcag/sc/1.4.3.html)

The main reasons behind this are to:

* make the links on the homepage more meaningful and fix #141 
* make the links consistent in order to pass Consistent Identification
* add the level to each links as agreed in our working group

It also:

* includes some text tweaks at the start of the homepage's WCAG Overview section.
* adds links from the homepage to the available new WCAG 2.2 criteria (all but one)

I've tested the homepage locally and it works for me. I've also spot checked links on other pages.