### PR TITLE
Add last updated dates

### DIFF
--- a/source/checklist.html.md.erb
+++ b/source/checklist.html.md.erb
@@ -4,6 +4,8 @@ title: Checklist
 
 # <%= current_page.data.title %>
 
+**This checklist is currently only updated to WCAG 2.1. It is under review and may be removed.**
+
 To meet WCAG 2.1 to level AA you must be able to answer YES or Not Applicable to all of the following questions.
 
 Answering NO means that you are not meeting WCAG and your content will have barriers that will prevent some users, especially disabled users and older people from accessing it.
@@ -58,3 +60,6 @@ Answering NO means that you are not meeting WCAG and your content will have barr
 * Do all interactive components have an accessible name and role, and when required state? Has the correct ARIA markup been used and does it validate?
 * Are status messages and updates given appropriate roles that can be understood by AT, without receiving focus?
 
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/community.html.md.erb
+++ b/source/community.html.md.erb
@@ -13,3 +13,7 @@ You can help make sure it stays up to date by:
 1. Making changes to the [guide to WCAG on Github](https://github.com/alphagov/guide-to-wcag).
 
 2. Emailing the Accessibility Guide team at <accessibility-guide@digital.cabinet-office.gov.uk> with suggestions
+
+## Last updated
+
+This page was last updated in December 2025.

--- a/source/content.html.md.erb
+++ b/source/content.html.md.erb
@@ -60,6 +60,6 @@ Here are the details of the success criteria that are related to content.
 
 ## Robust
 
-### 4.1.3 Status Messages
+### 4.1 Compatible
 
 * <%= link_to "4.1.3 Status Messages (AA)", "/sc/4.1.3.html" %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -206,3 +206,7 @@ View [all success criteria](/all.html), or those that are related to [content](/
 ## How to give feedback
 
 Use the "Report problem" link at the end of each page if you spot any issues with this guide.
+
+## Last updated
+
+This page was last updated in March 2026.

--- a/source/sc/1.1.1.html.md.erb
+++ b/source/sc/1.1.1.html.md.erb
@@ -26,3 +26,7 @@ All non-text content like images, charts, icons and infographics, must have an a
 
 *   [W3C Requirements for providing text to act as an alternative for images](https://www.w3.org/TR/html51/semantics-embedded-content.html#alt-text)
 *   [W3C Alt text decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/)
+
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/1.2.1.html.md.erb
+++ b/source/sc/1.2.1.html.md.erb
@@ -25,3 +25,7 @@ All content that is audio-only like a podcast, or video-only like a silent movie
 ## Useful resources
 
 *   [What are transcripts?](https://www.nomensa.com/blog/2010/what-are-transcripts/)
+
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/1.2.2.html.md.erb
+++ b/source/sc/1.2.2.html.md.erb
@@ -24,3 +24,6 @@ Video content like instructional videos, promotions and interviews, must have ca
 *   [What are captions?](https://www.nomensa.com/blog/2010/what-are-captions)
 *   [Sounding out the web: accessibility for Deaf and hard of hearing people (Part 2](https://www.paciellogroup.com/blog/2017/03/sounding-out-the-web-accessibility-for-deaf-and-hard-of-hearing-people-part-2/)
 
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/1.2.3.html.md.erb
+++ b/source/sc/1.2.3.html.md.erb
@@ -22,3 +22,7 @@ Video content like instructional videos must have audio description, unless it a
 ## Useful resources
 
 *   [What is audio description?](https://www.nomensa.com/blog/2010/what-is-audio-description)
+
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/1.2.4.html.md.erb
+++ b/source/sc/1.2.4.html.md.erb
@@ -21,3 +21,7 @@ Live broadcast video must have captions that are synchronised with the audio con
 
 *   [What are captions?](https://www.nomensa.com/blog/2010/what-are-captions)
 *   [Sounding out the web: accessibility for Deaf and hard of hearing people (Part 2](https://www.paciellogroup.com/blog/2017/03/sounding-out-the-web-accessibility-for-deaf-and-hard-of-hearing-people-part-2/)
+
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/1.2.5.html.md.erb
+++ b/source/sc/1.2.5.html.md.erb
@@ -75,3 +75,7 @@ It is also worth being aware of the following AAA criteria:
 
 * [Adding an audio description to your videos - Government Communication Service](https://www.communications.gov.uk/guidance/accessible-communications/adding-an-audio-description-to-your-videos/)
 * [Description of visual information guidance on Web Accessibility Initiative (WAI) by World Wide Web Consortium (W3C)](https://www.w3.org/WAI/media/av/description/)
+
+## Last updated
+
+This page was last updated in April 2026.

--- a/source/sc/1.3.1.html.md.erb
+++ b/source/sc/1.3.1.html.md.erb
@@ -164,3 +164,7 @@ This success criterion is closely related to several others. In some cases, more
 * [2.5.3 Label in Name (A)](2.5.3.html) makes sure that a component's name (in the code) contains the visible label.
 * [3.3.2 Labels or Instructions (A)](3.3.2.html) makes sure that elements have labels, but does not require them to be associated with each other.
 * [4.1.2 Name, Role, Value (A)](4.1.2.html) interactive elements having appropriate names, roles and values, regardless of how they appear visually.
+
+## Last updated
+
+This page was last updated in December 2025.

--- a/source/sc/1.3.2.html.md.erb
+++ b/source/sc/1.3.2.html.md.erb
@@ -24,3 +24,7 @@ When the order of content is important, the content order must be preserved no m
 
 *   [FlexBox and the keyboard navigation disconnect](http://tink.uk/flexbox-the-keyboard-navigation-disconnect/)
 *   [Using the tabindex attribute](https://www.paciellogroup.com/blog/2014/08/using-the-tabindex-attribute/)
+
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/1.3.3.html.md.erb
+++ b/source/sc/1.3.3.html.md.erb
@@ -19,3 +19,6 @@ Instructions must not depend on sensory characteristics like shape, size, colour
 *   An instruction tells users they can “find more information in the square box”;
 *   An instruction tells users to “follow the biggest link in the tag cloud”.
 
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/1.3.4.html.md.erb
+++ b/source/sc/1.3.4.html.md.erb
@@ -55,3 +55,7 @@ To pass this success criterion, it's only important that the user is not forced 
 ## Useful resources
 
 * [Managing screen orientation - MDN](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation)
+
+## Last updated
+
+This page was last updated in December 2025.

--- a/source/sc/1.3.5.html.md.erb
+++ b/source/sc/1.3.5.html.md.erb
@@ -51,3 +51,7 @@ The content is created using HTML or supported by a language which can identify 
 ```
 
 Example of a form collecting data on a user with autofill examples.
+
+## Last updated
+
+This page was last updated in February 2019.

--- a/source/sc/1.4.1.html.md.erb
+++ b/source/sc/1.4.1.html.md.erb
@@ -58,3 +58,7 @@ In general, the following examples fail:
 
 * [1.4.3 Contrast (Minimum) (AA)](1.4.3.html) makes sure that text has enough contrast, regardless of whether it relies on colour to distinguish it.
 * [1.4.11 Non-text Contrast (AA)](1.4.11.html) makes sure that components have enough contrast to be visible, regardless of whether they are distinguishable using colour. This can apply to icons, form fields or keyboard focus indicators.
+
+## Last updated
+
+This page was last updated in September 2025.

--- a/source/sc/1.4.10.html.md.erb
+++ b/source/sc/1.4.10.html.md.erb
@@ -29,8 +29,8 @@ Where content is zoomed there should be no loss of information or functionality.
 
 ## Useful resources
 
-* Try [triggering horizontal scrolling in vertical languages](https://www.w3.org/International/articles/vertical-text/index-data/embedded-ar.html).  
+* Try [triggering horizontal scrolling in vertical languages](https://www.w3.org/International/articles/vertical-text/index-data/embedded-ar.html).
 
+## Last updated
 
-
-
+This page was last updated in February 2019.

--- a/source/sc/1.4.11.html.md.erb
+++ b/source/sc/1.4.11.html.md.erb
@@ -68,3 +68,7 @@ An orange focus indicator on a white page has insufficient contrast to be able t
 
 * [Understanding 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast) has several visual examples of good and bad practice.
 * [WebAim Contrast Checker](https://webaim.org/resources/contrastchecker/) is a free online tool that can be used for checking contrast.
+
+## Last updated
+
+This page was last updated in September 2025.

--- a/source/sc/1.4.12.html.md.erb
+++ b/source/sc/1.4.12.html.md.erb
@@ -29,8 +29,6 @@ Make sure that all text fits within its containing box without being cut off or 
 
 *  Not allowing or restricting the user from overriding text style.
 
-## Resources
-
 ### Techniques for:
 
 * [Allowing for text spacing override](https://www.w3.org/WAI/WCAG21/Techniques/css/C36)
@@ -39,6 +37,6 @@ Make sure that all text fits within its containing box without being cut off or 
 * [Specifying line spacing in CSS](https://www.w3.org/WAI/WCAG21/Techniques/css/C21)
 * [Specifying the size of text containers using em units](https://www.w3.org/WAI/WCAG21/Techniques/css/C28)
 
+## Last updated
 
-
-
+This page was last updated in February 2019.

--- a/source/sc/1.4.13.html.md.erb
+++ b/source/sc/1.4.13.html.md.erb
@@ -44,6 +44,6 @@ Once it appears, the content should remain visible until:
 * The user can’t dismiss content without moving pointer hover or keyboard focus.
 * Content on hover or focus does not stay visible until dismissed or invalid
 
-## Resources
+## Last updated
 
-* TBD
+This page was last updated in July 2018.

--- a/source/sc/1.4.2.html.md.erb
+++ b/source/sc/1.4.2.html.md.erb
@@ -17,6 +17,6 @@ When audio or video plays automatically on a page, it should last for less than 
 
 *   Audio or video plays automatically for more than three seconds, but cannot be paused or stopped by the user.
 
-## Useful resources
+## Last updated
 
-*   TBC
+This page was last updated in July 2018.

--- a/source/sc/1.4.3.html.md.erb
+++ b/source/sc/1.4.3.html.md.erb
@@ -92,3 +92,7 @@ This success criterion only relates to the contrast of text.
 * [1.4.1 Use of Colour (A)](1.4.1.html) requires that colour is not the only way to convey information.
 * [1.4.6 Contrast (Enhanced) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced) encourages you to use a minimum contrast ratio of 7:1 to meet level AAA.
 * [1.4.11 Non-text Contrast (AA)](1.4.11.html) covers the contrast of anything meaningful other than text.
+
+## Last updated
+
+This page was last updated in December 2025.

--- a/source/sc/1.4.4.html.md.erb
+++ b/source/sc/1.4.4.html.md.erb
@@ -11,3 +11,7 @@ It must be possible for people to increase the size of text by up to 200%. This 
 ## Requirements / What to do?
 
 *   We need to decide whether we want to use text resize or zoom as the preferred mechanism.
+
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/1.4.5.html.md.erb
+++ b/source/sc/1.4.5.html.md.erb
@@ -73,3 +73,7 @@ In this case, the text in the image cannot be enlarged, changed or read by assis
 * [1.1.1 Non-text Content (A)](1.1.1.html) covers images having a text alternative.
 * [1.4.3 Contrast (Minimum) (AA)](1.4.3.html) requires that text in images has sufficient contrast to the background.
 * [1.4.9 Images of Text (No Exception) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/images-of-text-no-exception) is a more strict AAA guideline with more restrictions.
+
+## Last updated
+
+This page was last updated in January 2026.

--- a/source/sc/2.1.1.html.md.erb
+++ b/source/sc/2.1.1.html.md.erb
@@ -73,3 +73,7 @@ While custom buttons can be made to be accessible, it takes extra effort to ensu
 * [2.4.7 Focus Visible (AA)](2.4.7.html) requires that you can see where keyboard focus currently is.
 * [2.4.11 Focus Not Obscured (Minimum) (AA)](2.4.11.html) requires that focused components are not hidden by other components.
 * [3.2.1 On Focus (A)](3.2.1.html) and [3.2.2 On Input](3.2.2.html) require that no disorienting changes happen when focusing on, or updating a user interface component.
+
+## Last updated
+
+This page was last updated in January 2026.

--- a/source/sc/2.1.2.html.md.erb
+++ b/source/sc/2.1.2.html.md.erb
@@ -17,6 +17,6 @@ When someone using a keyboard to navigate content moves to an element, they must
 *   A dialogue opens but cannot be closed with the keyboard, preventing the user from accessing the original content underneath;
 *   Content is presented in an infinite scroll, so a keyboard user is forced to tab through everything before they can exit the scroll area.
 
-## Useful resources
+## Last updated
 
-*   TBC
+This page was last updated in July 2018.

--- a/source/sc/2.1.4.html.md.erb
+++ b/source/sc/2.1.4.html.md.erb
@@ -38,5 +38,9 @@ You can see the issue in these character key shortcut video, with thanks to Kim 
 * [You Tube Video 1 - See how Speech affects single key shortcuts](https://www.youtube.com/watch?v=xzSyIA4OWYE)
 * [You Tube Video 2 - See how Speech affects single key shortcuts](https://www.youtube.com/watch?v=OPjfpDU9S08)
 
-The remapping method can include [non-printing characters](https://en.wikipedia.org/wiki/Control_character). 
+The remapping method can include [non-printing characters](https://en.wikipedia.org/wiki/Control_character).
+
+## Last updated
+
+This page was last updated in February 2019.
 

--- a/source/sc/2.2.1.html.md.erb
+++ b/source/sc/2.2.1.html.md.erb
@@ -20,3 +20,7 @@ When a time limit like a session timeout is set, it must be possible for the use
 ## Useful resources
 
 *   [Accessible timeout notifications](https://tink.uk/accessible-timeout-notifications/)
+
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/2.2.2.html.md.erb
+++ b/source/sc/2.2.2.html.md.erb
@@ -18,6 +18,6 @@ When content moves (is animated, blinks or scrolls) automatically for more than 
 
 *   Content moves for more than five seconds but there is no mechanism for a user to pause, stop or hide it.
 
-## Useful resources
+## Last updated
 
-*   TBC
+This page was last updated in July 2018.

--- a/source/sc/2.3.1.html.md.erb
+++ b/source/sc/2.3.1.html.md.erb
@@ -16,6 +16,6 @@ A page must not contain content that flashes more than three times a second. Thi
 
 *   Content flashes at more than three times a second.
 
-## Useful resources
+## Last updated
 
-*   TBC
+This page was last updated in July 2018.

--- a/source/sc/2.4.1.html.md.erb
+++ b/source/sc/2.4.1.html.md.erb
@@ -50,3 +50,7 @@ This link moves the visual and keyboard focus to the main content area, skipping
 ## Related success criteria
 
 [2.4.3 Focus Order (A)](2.4.3.html) ensures that the focus order around the page is logical, to help users navigate predictably using a keyboard.
+
+## Last updated
+
+This page was last updated in October 2025.

--- a/source/sc/2.4.11.html.md.erb
+++ b/source/sc/2.4.11.html.md.erb
@@ -61,3 +61,7 @@ This could be resolved by either restricting keyboard focus to the cookie dialog
 [2.4.7 Focus Visible (AA)](2.4.7.html) relates to focus indicators being visible. If a component has no visible focus indicator at all, it fails Focus Visible. If it has a visible focus indicator, but the component is hidden behind something else, it fails Focus Not Obscured.
 
 The stricter AAA criterion, explained on [Understanding 2.4.12 Focus Not Obscured (Enhanced) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-enhanced) encourages you not to hide components at all when they are focused.
+
+## Last updated
+
+This page was last updated in December 2025.

--- a/source/sc/2.4.2.html.md.erb
+++ b/source/sc/2.4.2.html.md.erb
@@ -88,3 +88,7 @@ While “friendly” filenames can help with understanding, a document's propert
 * [2.4.4 Link Purpose (In Context) (A)](2.4.4.html) requires that links have text which makes sense in context.
 * [2.4.5 Multiple Ways (AA)](2.4.5.html) requires there to be at least two ways of finding a page. If one of those methods is search, then accurate page titles are important to help meet this.
 * [2.4.6 Headings and Labels (AA)](2.4.6.html) requires that headings within pages, and component labels are descriptive.
+
+## Last updated
+
+This page was last updated in January 2026.

--- a/source/sc/2.4.3.html.md.erb
+++ b/source/sc/2.4.3.html.md.erb
@@ -76,3 +76,7 @@ The following scenarios may also have an impact on focus order:
 
 * [Focus - Home Office Design System Accessibility pages](https://design.homeoffice.gov.uk/accessibility/interactivity/keyboard/focus)
 * [How to activate keyboard navigation on MacOS (A11y Collective)](https://www.a11y-collective.com/blog/how-to-activate-keyboard-navigation-on-macos/)
+
+## Last updated
+
+This page was last updated in January 2026.

--- a/source/sc/2.4.4.html.md.erb
+++ b/source/sc/2.4.4.html.md.erb
@@ -85,3 +85,7 @@ This success criterion specifically relates to links being descriptive.
 ## Useful links
 
 * [GOV.UK content design guidance: Using links in content](https://www.gov.uk/guidance/content-design/links#using-links-in-content)
+
+## Last updated
+
+This page was last updated in August 2025.

--- a/source/sc/2.4.5.html.md.erb
+++ b/source/sc/2.4.5.html.md.erb
@@ -60,3 +60,7 @@ Common mistakes include:
 
 * [2.4.2 Page Titled (A)](2.4.2.html) helps to make it easier to find pages by making sure they have descriptive titles.
 * [3.2.3 Consistent Navigation (AA)](3.2.3.html) makes sure that navigation menus are always presented in a consistent order.
+
+## Last updated
+
+This page was last updated in August 2025.

--- a/source/sc/2.4.6.html.md.erb
+++ b/source/sc/2.4.6.html.md.erb
@@ -18,6 +18,6 @@ Headings must indicate the topic or purpose of the content in that section of th
 *   A heading does not indicate the purpose or topic of the content that follows;
 *   A label does not indicate the purpose of the field it relates to.
 
-## Useful resources
+## Last updated
 
-*   TBC
+This page was last updated in July 2018.

--- a/source/sc/2.4.7.html.md.erb
+++ b/source/sc/2.4.7.html.md.erb
@@ -65,3 +65,7 @@ This success criterion only requires that a focus indicator is visible without s
 * [3.2.1 On Focus (A)](3.2.1.html) requires focus to stay where it is when an element receives focus.
 
 Also, [Understanding 2.4.13 Focus Appearance (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance) has more guidance on how visible a focus indicator should be.
+
+## Last updated
+
+This page was last updated in September 2025.

--- a/source/sc/2.5.1.html.md.erb
+++ b/source/sc/2.5.1.html.md.erb
@@ -43,3 +43,7 @@ Some examples are:
 ## Resources
 
 * [Knowability - Example of Pointer Gestures](https://knowbility.org/blog/2018/WCAG21-251PointerGestures/)
+
+## Last updated
+
+This page was last updated in February 2019.

--- a/source/sc/2.5.2.html.md.erb
+++ b/source/sc/2.5.2.html.md.erb
@@ -55,3 +55,7 @@ The up-event may have different names, such as "touchend" or "mouseup".
 * [Mozilla - Using Touch Events](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Using_Touch_Events)
 * [Input events on Android](https://developer.android.com/guide/topics/ui/ui-events)
 * [Mozilla - Pointer Events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)
+
+## Last updated
+
+This page was last updated in February 2019.

--- a/source/sc/2.5.3.html.md.erb
+++ b/source/sc/2.5.3.html.md.erb
@@ -36,3 +36,6 @@ Ensure that the:
 
 * [Knowability - Article on ‘Label in Name’ with examples](https://knowbility.org/blog/2018/WCAG21-253LabelInName/)
 
+## Last updated
+
+This page was last updated in February 2019.

--- a/source/sc/2.5.4.html.md.erb
+++ b/source/sc/2.5.4.html.md.erb
@@ -41,3 +41,6 @@ Notice how most of these following example are just about common sense alternati
 * [Mac: Reduce Motion](https://apple.stackexchange.com/questions/253756/speed-up-mission-control-animations-in-macos-sierra)
 * [Windows 10: Reduce motion](https://www.laptopmag.com/articles/disable-minimize-maximize-animations-windows-10)
 
+## Last updated
+
+This page was last updated in February 2019.

--- a/source/sc/2.5.7.html.md.erb
+++ b/source/sc/2.5.7.html.md.erb
@@ -105,3 +105,7 @@ Dragging Movements relates to other criteria which help users navigate content i
 ## Useful resources
 
 * Video: [WCAG 2.2 - Dragging Movements - 2.5.7 - Accessible alternatives (Silktide)](https://www.youtube.com/watch?v=8YxvkKgq95g)
+
+## Last updated
+
+This page was last updated in April 2026.

--- a/source/sc/2.5.8.html.md.erb
+++ b/source/sc/2.5.8.html.md.erb
@@ -78,3 +78,7 @@ To achieve AAA compliance and meet [2.5.5 Target Size (Enhanced)](https://www.w3
 ## Useful resources
 
 * [TPGi: How to test 2.5.8 Target Size (Minimum)](https://www.tpgi.com/how-to-test-2-5-8-target-size-minimum/)
+
+## Last updated
+
+This page was last updated in December 2025.

--- a/source/sc/3.1.1.html.md.erb
+++ b/source/sc/3.1.1.html.md.erb
@@ -96,3 +96,7 @@ The `lang` attribute does not necessarily have to match the language of the majo
 * [Why use the language attribute? - W3C](https://www.w3.org/International/questions/qa-lang-why)
 * [Language on the Web - W3C](https://www.w3.org/International/getting-started/language)
 * [BCP 47 language tags - MDN](https://developer.mozilla.org/en-US/docs/Glossary/BCP\_47\_language\_tag)
+
+## Last updated
+
+This page was last updated in July 2025.

--- a/source/sc/3.1.2.html.md.erb
+++ b/source/sc/3.1.2.html.md.erb
@@ -96,3 +96,7 @@ This fails as the `lang` attribute's value is not valid.
 * [Why use the language attribute? - W3C](https://www.w3.org/International/questions/qa-lang-why)
 * [Language on the Web - W3C](https://www.w3.org/International/getting-started/language)
 * [BCP 47 language tags - MDN](https://developer.mozilla.org/en-US/docs/Glossary/BCP\_47\_language\_tag)
+
+## Last updated
+
+This page was last updated in July 2025.

--- a/source/sc/3.2.1.html.md.erb
+++ b/source/sc/3.2.1.html.md.erb
@@ -19,6 +19,6 @@ When a keyboard user focuses on a control it must not cause a change of context,
 *   Javascript triggers navigation when a user is merely leaving a form control
 *   focus is moved by script in ways that surprise the user
 
-## Useful resources
+## Last updated
 
-*   TBC
+This page was last updated in July 2018.

--- a/source/sc/3.2.2.html.md.erb
+++ b/source/sc/3.2.2.html.md.erb
@@ -21,3 +21,7 @@ Changing the setting of any user interface component does not automatically caus
 ## Useful resources
 
 *   [Using ARIA](https://w3c.github.io/using-aria/)
+
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/3.2.3.html.md.erb
+++ b/source/sc/3.2.3.html.md.erb
@@ -17,6 +17,6 @@ When ways to navigate content are repeated on multiple pages, they must be prese
 *   A main navigation block is used on multiple pages, but is located in a different place on each page;
 *   A breadcrumb navigation is used on multiple pages, but is presented in a different format on each page.
 
-## Useful resources
+## Last updated
 
-*   TBC.
+This page was last updated in July 2018.

--- a/source/sc/3.2.4.html.md.erb
+++ b/source/sc/3.2.4.html.md.erb
@@ -19,6 +19,6 @@ When features with the same functionality are used in multiple places, they must
 *   An icon is used to denote a file download, but has a different alternate text whenever it is used;
 *   A search facility is provided on every page, but the text field and button have different labels on each page.
 
-## Useful resources
+## Last updated
 
-*   TBC.
+This page was last updated in July 2018.

--- a/source/sc/3.2.6.html.md.erb
+++ b/source/sc/3.2.6.html.md.erb
@@ -71,3 +71,7 @@ Consistent Help is at level A but overlaps closely with the following level AA c
 
 * [3.2.3 Consistent Navigation (AA)](3.2.3.html) requires that repeated navigational elements (such as menu links) appear in the same relative order.
 * [3.2.4 Consistent Identification (AA)](3.2.4.html) requires that repeated functionality has consistent labels. For example, the same link should not be labelled "Help" on one page and "Support" on another.
+
+## Last updated
+
+This page was last updated in January 2026.

--- a/source/sc/3.3.1.html.md.erb
+++ b/source/sc/3.3.1.html.md.erb
@@ -22,6 +22,6 @@ When an error occurs the user is informed what caused the error, and the error i
 *   Multiple errors occur, but no summary is provided.
 *   An error summary is provided, but keyboard focus is not taken to it.
 
-## Useful resources
+## Last updated
 
-*   TBC
+This page was last updated in July 2018.

--- a/source/sc/3.3.2.html.md.erb
+++ b/source/sc/3.3.2.html.md.erb
@@ -22,3 +22,7 @@ When data must be entered in a specific format or in a particular way, clear ins
 
 *   [Using aria-describedby to provide form hints](https://www.paciellogroup.com/blog/2014/12/using-aria-describedby-to-provide-helpful-form-hints/)
 *   [Basic form hints](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/forms/Basic_form_hints)
+
+## Last updated
+
+This page was last updated in December 2019.

--- a/source/sc/3.3.3.html.md.erb
+++ b/source/sc/3.3.3.html.md.erb
@@ -16,6 +16,6 @@ When an error is detected, suggestions for correcting the issue must be provided
 
 *   An error is detected and the user is notified, but no suggestion is given to help them resolve it; A login error is detected and a suggestion is provided, but it comprimises security by revelaing that a particular username exists.
 
-## Useful resources
+## Last updated
 
-*   TBC.
+This page was last updated in August 2019.

--- a/source/sc/3.3.4.html.md.erb
+++ b/source/sc/3.3.4.html.md.erb
@@ -22,3 +22,6 @@ When completion of a form causes a legal commitment, triggers a financial transa
 * [Requesting confirmation to continue with selected action](https://www.w3.org/WAI/WCAG21/Techniques/general/G168)
 * [Validating user input](https://www.w3.org/WAI/tutorials/forms/validation/)
 
+## Last updated
+
+This page was last updated in February 2019.

--- a/source/sc/3.3.7.html.md.erb
+++ b/source/sc/3.3.7.html.md.erb
@@ -64,3 +64,7 @@ In this example, a service is asking a user for a reference number that was alre
 
 * [3.3.4 Error Prevention (Legal, Financial, Data) (AA)](3.3.4.html) helps users to avoid errors by allowing them to confirm or correct information they have previously entered.
 * [3.3.8 Accessible Authentication (AA)](3.3.8.html) helps users to log in without having to re-type a password or code.
+
+## Last updated
+
+This page was last updated in February 2026.

--- a/source/sc/3.3.8.html.md.erb
+++ b/source/sc/3.3.8.html.md.erb
@@ -82,3 +82,7 @@ This could be improved by replacing the question with an object recognition test
 ## Useful resources
 
 [Video: Inspecting WCAG 2.2: accessible authentication](https://www.youtube.com/watch?v=9h5aLCS3wJQ) (by the GOV.UK Design System)
+
+## Last updated
+
+This page was last updated in December 2025.

--- a/source/sc/4.1.1.html.md.erb
+++ b/source/sc/4.1.1.html.md.erb
@@ -23,3 +23,7 @@ The code of the page must not cause browser or assistive technology conflicts. T
 ## Useful resources
 
 *   [W3C conformance validator](https://validator.w3.org/nu/)
+
+## Last updated
+
+This page was last updated in July 2018.

--- a/source/sc/4.1.2.html.md.erb
+++ b/source/sc/4.1.2.html.md.erb
@@ -104,3 +104,7 @@ Other criteria cover the need for interactive components to be descriptive (2.4.
 * [1.3.1 Info and Relationships (A)](1.3.1.html) relates to visual and programmatic information being presented consistently. While there is an overlap, Info and Relationships is more concerned with the structure of a page, and covers non-interactive elements.
 * [2.4.6 Headings and Labels (AA)](2.4.6.html) requires that any accessible names are descriptive. Name, Role, Value only ensures that they exist.
 * [3.3.2 Labels or Instructions (A)](3.3.2.html) requires that labels exist for all users.
+
+## Last updated
+
+This page was last updated in August 2025.

--- a/source/sc/4.1.3.html.md.erb
+++ b/source/sc/4.1.3.html.md.erb
@@ -59,5 +59,6 @@ You can use the following techniques:
 * Using <code>role="alert"</code> or <code>aria-live="assertive"</code> on content which is not important.
 * On a page with ARIA live regions - if regions are hidden or not needed - always make sure to switch their active and inactive states accordingly.
 
+## Last updated
 
-
+This page was last updated in February 2019.


### PR DESCRIPTION
This pull request adds "last updated" dates to the following pages in a format discussed within the working group:

* All success criteria
* Overview
* Checklist
* Community

The date reflects the last date that the core content was "significantly" updated - excluding things such as minor format changes.

Dates are not included on the lists of success criteria by role (All, Content, Design, Code) because these pages are expected to remain static. Also, it does not include the day of each update as that seems unnecessarily granular.

It also makes the following small changes:

* removing any "Resources - TBC" sections on older pages
* updating an incorrect heading on the Content page
* adding a disclaimer to the checklist to say that it is under review, as it is out of date