### PR TITLE
Add `updated` front matter and last updated dates.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -2,6 +2,15 @@ require 'govuk_tech_docs'
 
 GovukTechDocs.configure(self)
 
+# use custom.erb layout file
+set :layout, 'custom'
+
 # use relative paths for links and sources
 activate :relative_assets
 set :relative_links, true
+
+helpers do
+  def format_short_date(date)
+    Date.strptime(date, "%Y-%m").strftime("%B %Y")
+  end
+end

--- a/source/checklist.html.md.erb
+++ b/source/checklist.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: Checklist
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/community.html.md.erb
+++ b/source/community.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: Community
+updated: 2025-12
 ---
 
 # <%= current_page.data.title %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: A guide to WCAG
+updated: 2026-03
 ---
 
 # A guide to WCAG

--- a/source/layouts/custom.erb
+++ b/source/layouts/custom.erb
@@ -1,0 +1,9 @@
+<%# Extends the default template with some custom code %>
+
+<% wrap_layout :layout do %>
+  <%= yield %>
+  <% if current_page.data.updated %>
+    <h2>Last updated</h2>
+    <p>This page was last updated in <%= format_short_date current_page.data.updated %>.</p>
+  <% end %>
+<% end %>

--- a/source/sc/1.1.1.html.md.erb
+++ b/source/sc/1.1.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.1.1 Non-text Content (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.2.1.html.md.erb
+++ b/source/sc/1.2.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.2.1 Audio-only and Video-only (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.2.2.html.md.erb
+++ b/source/sc/1.2.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.2.2 Captions (Prerecorded) (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.2.3.html.md.erb
+++ b/source/sc/1.2.3.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.2.3 Audio Description or Media Alternative (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.2.4.html.md.erb
+++ b/source/sc/1.2.4.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.2.4 Captions (Live) (AA)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.2.5.html.md.erb
+++ b/source/sc/1.2.5.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.2.5 Audio Description (Prerecorded) (AA)
+updated: 2026-04
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.3.1.html.md.erb
+++ b/source/sc/1.3.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.3.1 Info and Relationships (A)
+updated: 2025-12
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.3.2.html.md.erb
+++ b/source/sc/1.3.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.3.2 Meaningful Sequence (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.3.3.html.md.erb
+++ b/source/sc/1.3.3.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.3.3 Sensory Characteristics (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.3.4.html.md.erb
+++ b/source/sc/1.3.4.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.3.4 Orientation (A)
+updated: 2025-12
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.3.5.html.md.erb
+++ b/source/sc/1.3.5.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.3.5 Identify Input Purpose (AA)
+updated: 2019-02
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.4.1.html.md.erb
+++ b/source/sc/1.4.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.4.1 Use of Colour (A)
+updated: 2025-09
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.4.10.html.md.erb
+++ b/source/sc/1.4.10.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.4.10 Reflow (AA)
+updated: 2019-02
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.4.11.html.md.erb
+++ b/source/sc/1.4.11.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.4.11 Non-text Contrast (AA)
+updated: 2025-09
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.4.12.html.md.erb
+++ b/source/sc/1.4.12.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.4.12 Text Spacing (AA)
+updated: 2019-02
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.4.13.html.md.erb
+++ b/source/sc/1.4.13.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.4.13 Content on Hover or Focus (AA)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.4.2.html.md.erb
+++ b/source/sc/1.4.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.4.2 Audio Control (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.4.3.html.md.erb
+++ b/source/sc/1.4.3.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.4.3 Contrast (Minimum) (AA)
+updated: 2025-12
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.4.4.html.md.erb
+++ b/source/sc/1.4.4.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.4.4 Resize Text (AA)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/1.4.5.html.md.erb
+++ b/source/sc/1.4.5.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 1.4.5 Images of Text (AA)
+updated: 2026-01
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.1.1.html.md.erb
+++ b/source/sc/2.1.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.1.1 Keyboard (A)
+updated: 2026-01
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.1.2.html.md.erb
+++ b/source/sc/2.1.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.1.2 No Keyboard Trap (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.1.4.html.md.erb
+++ b/source/sc/2.1.4.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.1.4 Character Key Shortcuts (A)
+updated: 2019-02
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.2.1.html.md.erb
+++ b/source/sc/2.2.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.2.1 Timing Adjustable (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.2.2.html.md.erb
+++ b/source/sc/2.2.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.2.2 Pause, Stop, Hide (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.3.1.html.md.erb
+++ b/source/sc/2.3.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.3.1 Three Flashes or Below Threshold (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.4.1.html.md.erb
+++ b/source/sc/2.4.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.4.1 Bypass Blocks (A)
+updated: 2025-10
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.4.11.html.md.erb
+++ b/source/sc/2.4.11.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.4.11 Focus Not Obscured (Minimum) (AA)
+updated: 2025-12
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.4.2.html.md.erb
+++ b/source/sc/2.4.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.4.2 Page Titled (A)
+updated: 2026-01
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.4.3.html.md.erb
+++ b/source/sc/2.4.3.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.4.3 Focus Order (A)
+updated: 2026-01
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.4.4.html.md.erb
+++ b/source/sc/2.4.4.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.4.4 Link Purpose (In Context) (A)
+updated: 2025-08
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.4.5.html.md.erb
+++ b/source/sc/2.4.5.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.4.5 Multiple Ways (AA)
+updated: 2025-08
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.4.6.html.md.erb
+++ b/source/sc/2.4.6.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.4.6 Headings and Labels (AA)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.4.7.html.md.erb
+++ b/source/sc/2.4.7.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.4.7 Focus Visible (AA)
+updated: 2025-09
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.5.1.html.md.erb
+++ b/source/sc/2.5.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.5.1 Pointer Gestures (A)
+updated: 2019-02
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.5.2.html.md.erb
+++ b/source/sc/2.5.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.5.2 Pointer Cancellation (A)
+updated: 2019-02
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.5.3.html.md.erb
+++ b/source/sc/2.5.3.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.5.3 Label in Name (A)
+updated: 2019-02
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.5.4.html.md.erb
+++ b/source/sc/2.5.4.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.5.4 Motion Actuation (A)
+updated: 2019-02
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.5.7.html.md.erb
+++ b/source/sc/2.5.7.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.5.7 Dragging Movements (AA)
+updated: 2026-04
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/2.5.8.html.md.erb
+++ b/source/sc/2.5.8.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 2.5.8 Target Size (Minimum) (AA)
+updated: 2025-12
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.1.1.html.md.erb
+++ b/source/sc/3.1.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.1.1 Language of Page (A)
+updated: 2025-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.1.2.html.md.erb
+++ b/source/sc/3.1.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.1.2 Language of Parts (AA)
+updated: 2025-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.2.1.html.md.erb
+++ b/source/sc/3.2.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.2.1 On Focus (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.2.2.html.md.erb
+++ b/source/sc/3.2.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.2.2 On Input (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.2.3.html.md.erb
+++ b/source/sc/3.2.3.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.2.3 Consistent Navigation (AA)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.2.4.html.md.erb
+++ b/source/sc/3.2.4.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.2.4 Consistent Identification (AA)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.2.6.html.md.erb
+++ b/source/sc/3.2.6.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.2.6 Consistent Help (A)
+updated: 2026-01
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.3.1.html.md.erb
+++ b/source/sc/3.3.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.3.1 Error Identification (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.3.2.html.md.erb
+++ b/source/sc/3.3.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.3.2 Labels or Instructions (A)
+updated: 2019-12
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.3.3.html.md.erb
+++ b/source/sc/3.3.3.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.3.3 Error Suggestion (AA)
+updated: 2019-08
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.3.4.html.md.erb
+++ b/source/sc/3.3.4.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.3.4 Error Prevention (Legal, Financial, Data) (AA)
+updated: 2019-02
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.3.7.html.md.erb
+++ b/source/sc/3.3.7.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.3.7 Redundant Entry (A)
+updated: 2026-02
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/3.3.8.html.md.erb
+++ b/source/sc/3.3.8.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 3.3.8 Accessible Authentication (Minimum) (AA)
+updated: 2025-12
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/4.1.1.html.md.erb
+++ b/source/sc/4.1.1.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 4.1.1 Parsing (A)
+updated: 2018-07
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/4.1.2.html.md.erb
+++ b/source/sc/4.1.2.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 4.1.2 Name, Role, Value (A)
+updated: 2025-08
 ---
 
 # <%= current_page.data.title %>

--- a/source/sc/4.1.3.html.md.erb
+++ b/source/sc/4.1.3.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: 4.1.3 Status Messages (AA)
+updated: 2019-02
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
This supersedes the addition of updated dates in #193, however does not contain the other changes to copy that PR includes. 

## Changes

- Added support for an `updated` front matter property that takes a date in YYYY-MM format.
- Added custom date parser to convert YYYY-MM dates into human readable format. 
- Extended default tech docs template to automatically append copy with the updated date to pages that have one defined.
- Updated content pages with updated dates, taken from #193.  