### PR TITLE
Remove empty resource sections

### DIFF
--- a/source/sc/1.2.2.html.md.erb
+++ b/source/sc/1.2.2.html.md.erb
@@ -23,5 +23,4 @@ Video content like instructional videos, promotions and interviews, must have ca
 ## Useful resources
 
 *   [What are captions?](https://www.nomensa.com/blog/2010/what-are-captions)
-*   [Sounding out the web: accessibility for Deaf and hard of hearing people (Part 2](https://www.paciellogroup.com/blog/2017/03/sounding-out-the-web-accessibility-for-deaf-and-hard-of-hearing-people-part-2/)
-
+*   [Sounding out the web: accessibility for Deaf and hard of hearing people (Part 2)](https://www.paciellogroup.com/blog/2017/03/sounding-out-the-web-accessibility-for-deaf-and-hard-of-hearing-people-part-2/)

--- a/source/sc/1.3.3.html.md.erb
+++ b/source/sc/1.3.3.html.md.erb
@@ -19,4 +19,3 @@ Instructions must not depend on sensory characteristics like shape, size, colour
 *   An instruction tells users to “use the menu on the left of the page”;
 *   An instruction tells users they can “find more information in the square box”;
 *   An instruction tells users to “follow the biggest link in the tag cloud”.
-

--- a/source/sc/1.4.10.html.md.erb
+++ b/source/sc/1.4.10.html.md.erb
@@ -31,7 +31,3 @@ Where content is zoomed there should be no loss of information or functionality.
 ## Useful resources
 
 * Try [triggering horizontal scrolling in vertical languages](https://www.w3.org/International/articles/vertical-text/index-data/embedded-ar.html).  
-
-
-
-

--- a/source/sc/1.4.12.html.md.erb
+++ b/source/sc/1.4.12.html.md.erb
@@ -30,8 +30,6 @@ Make sure that all text fits within its containing box without being cut off or 
 
 *  Not allowing or restricting the user from overriding text style.
 
-## Resources
-
 ### Techniques for:
 
 * [Allowing for text spacing override](https://www.w3.org/WAI/WCAG21/Techniques/css/C36)
@@ -39,7 +37,3 @@ Make sure that all text fits within its containing box without being cut off or 
 * [Using CSS letter-spacing to control spacing within a word](https://www.w3.org/WAI/WCAG21/Techniques/css/C8)
 * [Specifying line spacing in CSS](https://www.w3.org/WAI/WCAG21/Techniques/css/C21)
 * [Specifying the size of text containers using em units](https://www.w3.org/WAI/WCAG21/Techniques/css/C28)
-
-
-
-

--- a/source/sc/1.4.13.html.md.erb
+++ b/source/sc/1.4.13.html.md.erb
@@ -44,7 +44,3 @@ Once it appears, the content should remain visible until:
 * [Content shown on hover not being hoverable](https://www.w3.org/WAI/WCAG21/Techniques/failures/F95)
 * The user can’t dismiss content without moving pointer hover or keyboard focus.
 * Content on hover or focus does not stay visible until dismissed or invalid
-
-## Resources
-
-* TBD

--- a/source/sc/1.4.2.html.md.erb
+++ b/source/sc/1.4.2.html.md.erb
@@ -17,7 +17,3 @@ When audio or video plays automatically on a page, it should last for less than 
 ## Common mistakes
 
 *   Audio or video plays automatically for more than three seconds, but cannot be paused or stopped by the user.
-
-## Useful resources
-
-*   TBC

--- a/source/sc/2.1.2.html.md.erb
+++ b/source/sc/2.1.2.html.md.erb
@@ -17,7 +17,3 @@ When someone using a keyboard to navigate content moves to an element, they must
 
 *   A dialogue opens but cannot be closed with the keyboard, preventing the user from accessing the original content underneath;
 *   Content is presented in an infinite scroll, so a keyboard user is forced to tab through everything before they can exit the scroll area.
-
-## Useful resources
-
-*   TBC

--- a/source/sc/2.1.4.html.md.erb
+++ b/source/sc/2.1.4.html.md.erb
@@ -40,4 +40,3 @@ You can see the issue in these character key shortcut video, with thanks to Kim 
 * [You Tube Video 2 - See how Speech affects single key shortcuts](https://www.youtube.com/watch?v=OPjfpDU9S08)
 
 The remapping method can include [non-printing characters](https://en.wikipedia.org/wiki/Control_character). 
-

--- a/source/sc/2.2.2.html.md.erb
+++ b/source/sc/2.2.2.html.md.erb
@@ -18,7 +18,3 @@ When content moves (is animated, blinks or scrolls) automatically for more than 
 ## Common mistakes
 
 *   Content moves for more than five seconds but there is no mechanism for a user to pause, stop or hide it.
-
-## Useful resources
-
-*   TBC

--- a/source/sc/2.3.1.html.md.erb
+++ b/source/sc/2.3.1.html.md.erb
@@ -16,7 +16,3 @@ A page must not contain content that flashes more than three times a second. Thi
 ## Common mistakes
 
 *   Content flashes at more than three times a second.
-
-## Useful resources
-
-*   TBC

--- a/source/sc/2.4.6.html.md.erb
+++ b/source/sc/2.4.6.html.md.erb
@@ -18,7 +18,3 @@ Headings must indicate the topic or purpose of the content in that section of th
 
 *   A heading does not indicate the purpose or topic of the content that follows;
 *   A label does not indicate the purpose of the field it relates to.
-
-## Useful resources
-
-*   TBC

--- a/source/sc/2.5.3.html.md.erb
+++ b/source/sc/2.5.3.html.md.erb
@@ -36,4 +36,3 @@ Ensure that the:
 ## Resources
 
 * [Knowability - Article on ‘Label in Name’ with examples](https://knowbility.org/blog/2018/WCAG21-253LabelInName/)
-

--- a/source/sc/2.5.4.html.md.erb
+++ b/source/sc/2.5.4.html.md.erb
@@ -41,4 +41,3 @@ Notice how most of these following example are just about common sense alternati
 * [iOS: Reduce Motion on iPhone, iPad or iPod touch](https://support.apple.com/en-gb/HT202655)
 * [Mac: Reduce Motion](https://apple.stackexchange.com/questions/253756/speed-up-mission-control-animations-in-macos-sierra)
 * [Windows 10: Reduce motion](https://www.laptopmag.com/articles/disable-minimize-maximize-animations-windows-10)
-

--- a/source/sc/3.2.1.html.md.erb
+++ b/source/sc/3.2.1.html.md.erb
@@ -19,7 +19,3 @@ When a keyboard user focuses on a control it must not cause a change of context,
 *   Dropdown menus trigger navigation as the user tabs between options
 *   Javascript triggers navigation when a user is merely leaving a form control
 *   focus is moved by script in ways that surprise the user
-
-## Useful resources
-
-*   TBC

--- a/source/sc/3.2.3.html.md.erb
+++ b/source/sc/3.2.3.html.md.erb
@@ -17,7 +17,3 @@ When ways to navigate content are repeated on multiple pages, they must be prese
 
 *   A main navigation block is used on multiple pages, but is located in a different place on each page;
 *   A breadcrumb navigation is used on multiple pages, but is presented in a different format on each page.
-
-## Useful resources
-
-*   TBC.

--- a/source/sc/3.2.4.html.md.erb
+++ b/source/sc/3.2.4.html.md.erb
@@ -19,7 +19,3 @@ When features with the same functionality are used in multiple places, they must
 
 *   An icon is used to denote a file download, but has a different alternate text whenever it is used;
 *   A search facility is provided on every page, but the text field and button have different labels on each page.
-
-## Useful resources
-
-*   TBC.

--- a/source/sc/3.3.1.html.md.erb
+++ b/source/sc/3.3.1.html.md.erb
@@ -22,7 +22,3 @@ When an error occurs the user is informed what caused the error, and the error i
 *   An error is described in text, but it is not associated with the field it relates to;
 *   Multiple errors occur, but no summary is provided.
 *   An error summary is provided, but keyboard focus is not taken to it.
-
-## Useful resources
-
-*   TBC

--- a/source/sc/3.3.3.html.md.erb
+++ b/source/sc/3.3.3.html.md.erb
@@ -16,7 +16,3 @@ When an error is detected, suggestions for correcting the issue must be provided
 ## Common mistakes
 
 *   An error is detected and the user is notified, but no suggestion is given to help them resolve it; A login error is detected and a suggestion is provided, but it comprimises security by revelaing that a particular username exists.
-
-## Useful resources
-
-*   TBC.

--- a/source/sc/3.3.4.html.md.erb
+++ b/source/sc/3.3.4.html.md.erb
@@ -22,4 +22,3 @@ When completion of a form causes a legal commitment, triggers a financial transa
 * [Let the user review and correct information before submission](https://www.w3.org/WAI/WCAG21/Techniques/general/G98).
 * [Requesting confirmation to continue with selected action](https://www.w3.org/WAI/WCAG21/Techniques/general/G168)
 * [Validating user input](https://www.w3.org/WAI/tutorials/forms/validation/)
-

--- a/source/sc/4.1.3.html.md.erb
+++ b/source/sc/4.1.3.html.md.erb
@@ -53,12 +53,8 @@ You can use the following techniques:
 * [Using role=log to identify sequential information updates](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA23)
 * [Using role=status to present status messages](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA22) in combination with [Providing help by an assistant in the Web page](https://www.w3.org/WAI/WCAG21/Techniques/general/G193)
 
-
 ## Common mistakes
 
 * Status messages are not to be shown in a way that the AT understands or receive focus.
 * Using <code>role="alert"</code> or <code>aria-live="assertive"</code> on content which is not important.
 * On a page with ARIA live regions - if regions are hidden or not needed - always make sure to switch their active and inactive states accordingly.
-
-
-


### PR DESCRIPTION
This pull request removes any sections that look like this, and standardises any empty lines at the end of every success criterion page:

> ## Resources
> 
> TBC.

This was originally proposed as part of #193 but has been separated out. I've spot checked a few pages locally and it looks fine.