### PR TITLE
Make corrections to list pages

### DIFF
--- a/source/all.html.md.erb
+++ b/source/all.html.md.erb
@@ -4,8 +4,8 @@ title: All WCAG A and AA Success Criteria
 
 # <%= current_page.data.title %>
 
-Here are the details of all 50 success criteria. 
-30 are level A and 20 are level AA.
+Here are the details of all 56 success criteria. 
+32 are level A and 24 are level AA.
 
 ## Perceivable
 

--- a/source/checklist.html.md.erb
+++ b/source/checklist.html.md.erb
@@ -5,6 +5,8 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
+**This checklist is currently only updated to WCAG 2.1. It is under review and may be removed.**
+
 To meet WCAG 2.1 to level AA you must be able to answer YES or Not Applicable to all of the following questions.
 
 Answering NO means that you are not meeting WCAG and your content will have barriers that will prevent some users, especially disabled users and older people from accessing it.
@@ -58,4 +60,3 @@ Answering NO means that you are not meeting WCAG and your content will have barr
 * Is the web page coded using valid HTML?
 * Do all interactive components have an accessible name and role, and when required state? Has the correct ARIA markup been used and does it validate?
 * Are status messages and updates given appropriate roles that can be understood by AT, without receiving focus?
-

--- a/source/content.html.md.erb
+++ b/source/content.html.md.erb
@@ -60,6 +60,6 @@ Here are the details of the success criteria that are related to content.
 
 ## Robust
 
-### 4.1.3 Status Messages
+### 4.1 Compatible
 
 * <%= link_to "4.1.3 Status Messages (AA)", "/sc/4.1.3.html" %>


### PR DESCRIPTION
This pull request makes the following corrections to list pages:

* Updates the number of success criteria on the All page to reflect WCAG 2.2
* Adds a note to the checklist page to acknowledge that it is only updated to WCAG 2.1 - as we haven't decided what we'll do with this yet
* Corrects the name of guideline 4.1 on the Content page

This was originally proposed as part of #193 but has been separated out.The changes look fine to me locally.