### PR TITLE
Fix incorrect number for Dragging Movements

### DIFF
--- a/source/sc/2.5.7.html.md.erb
+++ b/source/sc/2.5.7.html.md.erb
@@ -11,7 +11,7 @@ Don't rely on the user having to drag something on their screen to complete a ta
 
 > All functionality that uses a dragging movement for operation can be achieved by a single pointer without dragging, unless dragging is essential or the functionality is determined by the user agent and not modified by the author.
 
-[Understanding 2.5.8 Dragging Movements](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html)
+[Understanding 2.5.7 Dragging Movements](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html)
 
 ## What this means
 


### PR DESCRIPTION
This PR fixes a single typo, correcting the success criterion number on 2.5.7 Dragging Movements. The change looks fine to me locally.