### PR TITLE
Update link formats for Understanding pages

### DIFF
--- a/source/sc/1.1.1.html.md.erb
+++ b/source/sc/1.1.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)
 
 All non-text content like images, charts, icons and infographics, must have an appropriate text equivalent. This ensures that information conveyed by non-text content is available to people who cannot see it, like screen reader users.
 

--- a/source/sc/1.1.1.html.md.erb
+++ b/source/sc/1.1.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
 
 All non-text content like images, charts, icons and infographics, must have an appropriate text equivalent. This ensures that information conveyed by non-text content is available to people who cannot see it, like screen reader users.
 

--- a/source/sc/1.2.1.html.md.erb
+++ b/source/sc/1.2.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/audio-only-and-video-only-prerecorded.html)
 
 All content that is audio-only like a podcast, or video-only like a silent movie, must have a text description or an audio description. This ensures that information communicated for sight and sound is available to people who cannot see or hear.
 

--- a/source/sc/1.2.1.html.md.erb
+++ b/source/sc/1.2.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html)
 
 All content that is audio-only like a podcast, or video-only like a silent movie, must have a text description or an audio description. This ensures that information communicated for sight and sound is available to people who cannot see or hear.
 

--- a/source/sc/1.2.2.html.md.erb
+++ b/source/sc/1.2.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html)
 
 Video content like instructional videos, promotions and interviews, must have captions that are synchronised with the audio content of the video. This ensures that the information communicated by the audio part of the video is available to people who cannot hear it.
 

--- a/source/sc/1.2.2.html.md.erb
+++ b/source/sc/1.2.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/captions-prerecorded.html)
 
 Video content like instructional videos, promotions and interviews, must have captions that are synchronised with the audio content of the video. This ensures that the information communicated by the audio part of the video is available to people who cannot hear it.
 

--- a/source/sc/1.2.3.html.md.erb
+++ b/source/sc/1.2.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/audio-description-or-media-alternative-prerecorded.html)
 
 Video content like instructional videos must have audio description, unless it already has a text alternative. This ensures that information communicated visually in the video is available to people who cannot see it.
 

--- a/source/sc/1.2.3.html.md.erb
+++ b/source/sc/1.2.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded.html)
 
 Video content like instructional videos must have audio description, unless it already has a text alternative. This ensures that information communicated visually in the video is available to people who cannot see it.
 

--- a/source/sc/1.2.4.html.md.erb
+++ b/source/sc/1.2.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/captions-live.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/captions-live.html)
 
 Live broadcast video must have captions that are synchronised with the audio content of the video. This ensures that the information communicated by the audio part of the video is available to people who cannot hear it.
 

--- a/source/sc/1.2.4.html.md.erb
+++ b/source/sc/1.2.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/captions-live.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/captions-live.html)
 
 Live broadcast video must have captions that are synchronised with the audio content of the video. This ensures that the information communicated by the audio part of the video is available to people who cannot hear it.
 

--- a/source/sc/1.2.5.html.md.erb
+++ b/source/sc/1.2.5.html.md.erb
@@ -11,7 +11,7 @@ Provide an audio description for meaningful visual content in videos.
 
 > Audio description is provided for all prerecorded video content in synchronized media.
 
-[Understanding 1.2.5 Audio Description (Prerecorded)](https://www.w3.org/WAI/WCAG22/Understanding/audio-description-prerecorded.html)
+Check the official guidance for [Understanding 1.2.5 Audio Description (Prerecorded)](https://www.w3.org/WAI/WCAG22/Understanding/audio-description-prerecorded.html)
 
 ## What this means
 

--- a/source/sc/1.2.5.html.md.erb
+++ b/source/sc/1.2.5.html.md.erb
@@ -67,10 +67,10 @@ This success criterion is closely related to several others:
 * [1.2.2 Captions (Prerecorded) (A)](1.2.2.html) and [1.2.4 Captions (Live) (AA)](1.2.4.html) require that all videos with audio have captions.
 * [1.2.3 Audio Description or Media Alternative (Prerecorded) (A)](1.2.3.html) allows for there to be a transcript instead of an audio description when only meeting WCAG level A. However, at level AA, criterion 1.2.3 is meaningless because this criterion (1.2.5) says that there must be an audio description.
 
-It is also worth being aware of the following AAA criteria:
+It is also worth being aware of the following AAA criteria - links go to the official guidance:
 
-* [1.2.7 Extended audio description (Prerecorded) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/extended-audio-description-prerecorded) covers videos which pause to fit in a full audio description, when the gaps in the audio are too small to fit in a full description.
-* [1.2.8 Media Alternative (Prerecorded) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/media-alternative-prerecorded) adds the need for videos with audio to have a transcript.
+* [Understanding 1.2.7 Extended audio description (Prerecorded)](https://www.w3.org/WAI/WCAG22/Understanding/extended-audio-description-prerecorded) covers videos which pause to fit in a full audio description, when the gaps in the audio are too small to fit in a full description.
+* [Understanding 1.2.8 Media Alternative (Prerecorded)](https://www.w3.org/WAI/WCAG22/Understanding/media-alternative-prerecorded) adds the need for videos with audio to have a transcript.
 
 ## Useful resources
 

--- a/source/sc/1.3.1.html.md.erb
+++ b/source/sc/1.3.1.html.md.erb
@@ -9,7 +9,7 @@ updated: 2025-12
 
 > Information, structure, and relationships conveyed through presentation can be programmatically determined or are available in text.
 
-[Understanding 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships)
+Check the official guidance for [Understanding 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships)
 
 ## What this means
 

--- a/source/sc/1.3.2.html.md.erb
+++ b/source/sc/1.3.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/meaningful-sequence.html)
 
 When the order of content is important, the content order must be preserved no matter how it is presented to the user. This ensures that the order of content is meaningful whether someone is looking at it, listening to it with a screen reader, or has stripped out visual styling using a browser plugin.
 

--- a/source/sc/1.3.2.html.md.erb
+++ b/source/sc/1.3.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence.html)
 
 When the order of content is important, the content order must be preserved no matter how it is presented to the user. This ensures that the order of content is meaningful whether someone is looking at it, listening to it with a screen reader, or has stripped out visual styling using a browser plugin.
 

--- a/source/sc/1.3.3.html.md.erb
+++ b/source/sc/1.3.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/sensory-characteristics.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/sensory-characteristics.html)
 
 Instructions must not depend on sensory characteristics like shape, size, colour, or location. This ensures that instructions can be understood by users who are unable to see or recognise information communicated using sensory characteristics.
 

--- a/source/sc/1.3.3.html.md.erb
+++ b/source/sc/1.3.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/sensory-characteristics.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/sensory-characteristics.html)
 
 Instructions must not depend on sensory characteristics like shape, size, colour, or location. This ensures that instructions can be understood by users who are unable to see or recognise information communicated using sensory characteristics.
 

--- a/source/sc/1.3.4.html.md.erb
+++ b/source/sc/1.3.4.html.md.erb
@@ -9,7 +9,7 @@ updated: 2025-12
 
 > Content does not restrict its view and operation to a single display orientation, such as portrait or landscape, unless a specific display orientation is essential.
 
-[Understanding 1.3.4 Orientation](https://www.w3.org/WAI/WCAG22/Understanding/orientation)
+Check the official guidance for [Understanding 1.3.4 Orientation](https://www.w3.org/WAI/WCAG22/Understanding/orientation)
 
 ## What this means
 

--- a/source/sc/1.3.5.html.md.erb
+++ b/source/sc/1.3.5.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html)
 
 In an text input form the purpose of each input field that collects information about the user can be understood by Assistive Technologies and browsers, when:
 The input field serves a purpose that relates to the user of the content.

--- a/source/sc/1.3.5.html.md.erb
+++ b/source/sc/1.3.5.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html)
 
 In an text input form the purpose of each input field that collects information about the user can be understood by Assistive Technologies and browsers, when:
 The input field serves a purpose that relates to the user of the content.

--- a/source/sc/1.4.1.html.md.erb
+++ b/source/sc/1.4.1.html.md.erb
@@ -9,7 +9,7 @@ updated: 2025-09
 
 > Colour is not used as the only visual means of conveying information, indicating an action, prompting a response, or distinguishing a visual element.
 
-[Understanding 1.4.1 Use of Colour](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color)
+Check the official guidance for [Understanding 1.4.1 Use of Colour](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color)
 
 ## What this means
 

--- a/source/sc/1.4.10.html.md.erb
+++ b/source/sc/1.4.10.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html)
 
 Where content is zoomed there should be no loss of information or functionality. In particular on smaller devices or resolutions of 320px (vertically) or 256px (horizontally) there should be no scrolling in two directions when resized.
 

--- a/source/sc/1.4.10.html.md.erb
+++ b/source/sc/1.4.10.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html)
 
 Where content is zoomed there should be no loss of information or functionality. In particular on smaller devices or resolutions of 320px (vertically) or 256px (horizontally) there should be no scrolling in two directions when resized.
 

--- a/source/sc/1.4.11.html.md.erb
+++ b/source/sc/1.4.11.html.md.erb
@@ -9,7 +9,7 @@ updated: 2025-09
 
 > “The visual presentation of [user interface components and graphics] have a contrast ratio of at least 3:1 against adjacent colours” (with exceptions)
 
-[Understanding 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast)
+Check the official guidance for [Understanding 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast)
 
 ## What this means
 

--- a/source/sc/1.4.11.html.md.erb
+++ b/source/sc/1.4.11.html.md.erb
@@ -67,5 +67,5 @@ An orange focus indicator on a white page has insufficient contrast to be able t
 
 ## Useful links
 
-* [Understanding 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast) has several visual examples of good and bad practice.
+* The official guidance for [Understanding 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast) has several visual examples of good and bad practice.
 * [WebAim Contrast Checker](https://webaim.org/resources/contrastchecker/) is a free online tool that can be used for checking contrast.

--- a/source/sc/1.4.12.html.md.erb
+++ b/source/sc/1.4.12.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/text-spacing.html)
 
 For regular HTML page content, no loss of content or functionality happens with some changes to line height, letter or word spacing.
 

--- a/source/sc/1.4.12.html.md.erb
+++ b/source/sc/1.4.12.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html)
 
 For regular HTML page content, no loss of content or functionality happens with some changes to line height, letter or word spacing.
 

--- a/source/sc/1.4.13.html.md.erb
+++ b/source/sc/1.4.13.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/content-on-hover-or-focus.html)
 
 This is for mobile or tablet devices - where pointer hover or keyboard focus triggers additional content to become visible and then hidden (like pop-ups or other options) you need make sure:
 

--- a/source/sc/1.4.13.html.md.erb
+++ b/source/sc/1.4.13.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
 
 This is for mobile or tablet devices - where pointer hover or keyboard focus triggers additional content to become visible and then hidden (like pop-ups or other options) you need make sure:
 

--- a/source/sc/1.4.2.html.md.erb
+++ b/source/sc/1.4.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/audio-control.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/audio-control.html)
 
 When audio or video plays automatically on a page, it should last for less than three seconds or there must be a way to pause/stop it. This ensures that people who listen to content with a screen reader can do so without it being drowned out by the audio/video.
 

--- a/source/sc/1.4.2.html.md.erb
+++ b/source/sc/1.4.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/audio-control.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/audio-control.html)
 
 When audio or video plays automatically on a page, it should last for less than three seconds or there must be a way to pause/stop it. This ensures that people who listen to content with a screen reader can do so without it being drowned out by the audio/video.
 

--- a/source/sc/1.4.3.html.md.erb
+++ b/source/sc/1.4.3.html.md.erb
@@ -91,5 +91,5 @@ This blue link text does not have enough contrast when it has keyboard focus - t
 This success criterion only relates to the contrast of text.
 
 * [1.4.1 Use of Colour (A)](1.4.1.html) requires that colour is not the only way to convey information.
-* [1.4.6 Contrast (Enhanced) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced) encourages you to use a minimum contrast ratio of 7:1 to meet level AAA.
+* The official guidance for [Understanding 1.4.6 Contrast (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced) encourages you to use a minimum contrast ratio of 7:1 to meet level AAA.
 * [1.4.11 Non-text Contrast (AA)](1.4.11.html) covers the contrast of anything meaningful other than text.

--- a/source/sc/1.4.3.html.md.erb
+++ b/source/sc/1.4.3.html.md.erb
@@ -9,7 +9,7 @@ updated: 2025-12
 
 > "The visual presentation of text and images of text has a contrast ratio of at least 4.5:1" (with exceptions)
 
-[Understanding 1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum)
+Check the official guidance for [Understanding 1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum)
 
 ## What this means
 

--- a/source/sc/1.4.4.html.md.erb
+++ b/source/sc/1.4.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
 
 It must be possible for people to increase the size of text by up to 200%. This ensures that partially sighted people can comfortably read content.
 

--- a/source/sc/1.4.4.html.md.erb
+++ b/source/sc/1.4.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html)
 
 It must be possible for people to increase the size of text by up to 200%. This ensures that partially sighted people can comfortably read content.
 

--- a/source/sc/1.4.5.html.md.erb
+++ b/source/sc/1.4.5.html.md.erb
@@ -73,4 +73,4 @@ In this case, the text in the image cannot be enlarged, changed or read by assis
 
 * [1.1.1 Non-text Content (A)](1.1.1.html) covers images having a text alternative.
 * [1.4.3 Contrast (Minimum) (AA)](1.4.3.html) requires that text in images has sufficient contrast to the background.
-* [1.4.9 Images of Text (No Exception) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/images-of-text-no-exception) is a more strict AAA guideline with more restrictions.
+* The official guidance for [Understanding 1.4.9 Images of Text (No Exception)](https://www.w3.org/WAI/WCAG22/Understanding/images-of-text-no-exception) covers a more strict AAA guideline with more restrictions.

--- a/source/sc/1.4.5.html.md.erb
+++ b/source/sc/1.4.5.html.md.erb
@@ -9,7 +9,7 @@ updated: 2026-01
 
 > "If the technologies being used can achieve the visual presentation, text is used to convey information rather than images of text" (with exceptions)
 
-[Understanding 1.4.5 Images of Text](https://www.w3.org/WAI/WCAG22/Understanding/images-of-text.html)
+Check the official guidance for [Understanding 1.4.5 Images of Text](https://www.w3.org/WAI/WCAG22/Understanding/images-of-text.html)
 
 ## What this means
 

--- a/source/sc/2.1.1.html.md.erb
+++ b/source/sc/2.1.1.html.md.erb
@@ -9,7 +9,7 @@ updated: 2026-01
 
 > “All functionality of the content is operable through a keyboard interface…” (with additional notes)
 
-[Understanding 2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard)
+Check the official guidance for [Understanding 2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard)
 
 ## What this means
 

--- a/source/sc/2.1.2.html.md.erb
+++ b/source/sc/2.1.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap.html)
 
 When someone using a keyboard to navigate content moves to an element, they must be able to move away from it again. This ensures that people who use a keyboard do not get stuck on any part of the page.
 

--- a/source/sc/2.1.2.html.md.erb
+++ b/source/sc/2.1.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap.html)
 
 When someone using a keyboard to navigate content moves to an element, they must be able to move away from it again. This ensures that people who use a keyboard do not get stuck on any part of the page.
 

--- a/source/sc/2.1.4.html.md.erb
+++ b/source/sc/2.1.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html)
 
 If your webpage has keyboard shortcuts then one of the following must be true:
 * <strong>Turn off:</strong> The user must be able to turn them off;

--- a/source/sc/2.1.4.html.md.erb
+++ b/source/sc/2.1.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/character-key-shortcuts.html)
 
 If your webpage has keyboard shortcuts then one of the following must be true:
 * <strong>Turn off:</strong> The user must be able to turn them off;

--- a/source/sc/2.2.1.html.md.erb
+++ b/source/sc/2.2.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html)
 
 When a time limit like a session timeout is set, it must be possible for the user to turn it off, delay it, or extend the length of time. This ensures that people who need longer to complete tasks because of cognitive or mobility impairments, are able to do so comfortably.
 

--- a/source/sc/2.2.1.html.md.erb
+++ b/source/sc/2.2.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/timing-adjustable.html)
 
 When a time limit like a session timeout is set, it must be possible for the user to turn it off, delay it, or extend the length of time. This ensures that people who need longer to complete tasks because of cognitive or mobility impairments, are able to do so comfortably.
 

--- a/source/sc/2.2.2.html.md.erb
+++ b/source/sc/2.2.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html)
 
 When content moves (is animated, blinks or scrolls) automatically for more than five seconds, or when content automatically updates on the page, it must be possible for users to pause, stop or hide it. This ensures that people with cognitive disabilities that affect focus and concentration, are not distracted by movement.
 

--- a/source/sc/2.2.2.html.md.erb
+++ b/source/sc/2.2.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide.html)
 
 When content moves (is animated, blinks or scrolls) automatically for more than five seconds, or when content automatically updates on the page, it must be possible for users to pause, stop or hide it. This ensures that people with cognitive disabilities that affect focus and concentration, are not distracted by movement.
 

--- a/source/sc/2.3.1.html.md.erb
+++ b/source/sc/2.3.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/three-flashes-or-below-threshold.html)
 
 A page must not contain content that flashes more than three times a second. This ensures that people with conditions like photosensitive Epilepsy are protected from harmful seizures.
 

--- a/source/sc/2.3.1.html.md.erb
+++ b/source/sc/2.3.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold.html)
 
 A page must not contain content that flashes more than three times a second. This ensures that people with conditions like photosensitive Epilepsy are protected from harmful seizures.
 

--- a/source/sc/2.4.1.html.md.erb
+++ b/source/sc/2.4.1.html.md.erb
@@ -9,7 +9,7 @@ updated: 2025-10
 
 > A mechanism is available to bypass blocks of content that are repeated on multiple web pages.
 
-[Understanding 2.4.1 Bypass Blocks](https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks)
+Check the official guidance for [Understanding 2.4.1 Bypass Blocks](https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks)
 
 ## What this means
 

--- a/source/sc/2.4.11.html.md.erb
+++ b/source/sc/2.4.11.html.md.erb
@@ -61,4 +61,4 @@ This could be resolved by either restricting keyboard focus to the cookie dialog
 
 [2.4.7 Focus Visible (AA)](2.4.7.html) relates to focus indicators being visible. If a component has no visible focus indicator at all, it fails Focus Visible. If it has a visible focus indicator, but the component is hidden behind something else, it fails Focus Not Obscured.
 
-The stricter AAA criterion, explained on [Understanding 2.4.12 Focus Not Obscured (Enhanced) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-enhanced) encourages you not to hide components at all when they are focused.
+The stricter AAA criterion, explained in the official guidance on [Understanding 2.4.12 Focus Not Obscured (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-enhanced) encourages you not to hide components at all when they are focused.

--- a/source/sc/2.4.11.html.md.erb
+++ b/source/sc/2.4.11.html.md.erb
@@ -11,7 +11,7 @@ Make sure that people can always see any components that have keyboard focus.
 
 > When a user interface component receives keyboard focus, the component is not entirely hidden due to author-created content.
 
-[Understanding 2.4.11 Focus Not Obscured (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum)
+Check the official guidance for [Understanding 2.4.11 Focus Not Obscured (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum)
 
 ## What this means
 

--- a/source/sc/2.4.2.html.md.erb
+++ b/source/sc/2.4.2.html.md.erb
@@ -11,7 +11,7 @@ Pages need to have descriptive titles.
 
 > Web pages have titles that describe topic or purpose.
 
-[Understanding 2.4.2 Page Titled](https://www.w3.org/WAI/WCAG22/Understanding/page-titled)
+Check the official guidance for [Understanding 2.4.2 Page Titled](https://www.w3.org/WAI/WCAG22/Understanding/page-titled)
 
 ## What this means
 

--- a/source/sc/2.4.3.html.md.erb
+++ b/source/sc/2.4.3.html.md.erb
@@ -9,7 +9,7 @@ updated: 2026-01
 
 > If a web page can be navigated sequentially and the navigation sequences affect meaning or operation, focusable components receive focus in an order that preserves meaning and operability.
 
-[Understanding 2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order)
+Check the official guidance for [Understanding 2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order)
 
 ## What it means
 

--- a/source/sc/2.4.4.html.md.erb
+++ b/source/sc/2.4.4.html.md.erb
@@ -9,7 +9,7 @@ updated: 2025-08
 
 > "The purpose of each link can be determined from the link text alone or from the link text together with its programmatically determined link context" (with one exception)
 
-[Understanding 2.4.4 Link Purpose (In Context)](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context)
+Check the official guidance for [Understanding 2.4.4 Link Purpose (In Context)](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context)
 
 ## What this means
 

--- a/source/sc/2.4.5.html.md.erb
+++ b/source/sc/2.4.5.html.md.erb
@@ -9,7 +9,7 @@ updated: 2025-08
 
 > More than one way is available to locate a Web page within a set of Web pages except where the Web Page is the result of, or a step in, a process.
 
-[Understanding 2.4.5 Multiple Ways](https://www.w3.org/WAI/WCAG22/Understanding/multiple-ways)
+Check the official guidance for [Understanding 2.4.5 Multiple Ways](https://www.w3.org/WAI/WCAG22/Understanding/multiple-ways)
 
 ## What this means
 

--- a/source/sc/2.4.6.html.md.erb
+++ b/source/sc/2.4.6.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)
 
 Headings must indicate the topic or purpose of the content in that section of the page, and labels must indicate the purpose of the field they relate to. This ensures people with reading difficulties can understand the purpose of content, and that screen reader users can easily navigate to relevant sections of content on the page.
 

--- a/source/sc/2.4.6.html.md.erb
+++ b/source/sc/2.4.6.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html)
 
 Headings must indicate the topic or purpose of the content in that section of the page, and labels must indicate the purpose of the field they relate to. This ensures people with reading difficulties can understand the purpose of content, and that screen reader users can easily navigate to relevant sections of content on the page.
 

--- a/source/sc/2.4.7.html.md.erb
+++ b/source/sc/2.4.7.html.md.erb
@@ -9,7 +9,7 @@ updated: 2025-09
 
 > Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible.
 
-[Understanding 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible)
+Check the official guidance for [Understanding 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible)
 
 ## What this means
 

--- a/source/sc/2.4.7.html.md.erb
+++ b/source/sc/2.4.7.html.md.erb
@@ -65,4 +65,4 @@ This success criterion only requires that a focus indicator is visible without s
 * [2.4.11 Focus Not Obscured (Minimum) (AA)](2.4.11.html) requires elements that would normally have visible focus not to be covered by something else on screen.
 * [3.2.1 On Focus (A)](3.2.1.html) requires focus to stay where it is when an element receives focus.
 
-Also, [Understanding 2.4.13 Focus Appearance (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance) has more guidance on how visible a focus indicator should be.
+Also, the official guidance for [Understanding 2.4.13 Focus Appearance](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance) (AAA) goes further to explain how visible a focus indicator should be.

--- a/source/sc/2.5.1.html.md.erb
+++ b/source/sc/2.5.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/pointer-gestures.html)
 
 On mobile devices where you can use a touch - and need more than one finger or need to follow a path type gesture, functionality can still be operated using a single pointer.
 

--- a/source/sc/2.5.1.html.md.erb
+++ b/source/sc/2.5.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures.html)
 
 On mobile devices where you can use a touch - and need more than one finger or need to follow a path type gesture, functionality can still be operated using a single pointer.
 

--- a/source/sc/2.5.2.html.md.erb
+++ b/source/sc/2.5.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/pointer-cancellation.html)
 
 For mobile devices or tablets where if there is functionality triggered by a single pointer, at least one of the following is true:
 

--- a/source/sc/2.5.2.html.md.erb
+++ b/source/sc/2.5.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation.html)
 
 For mobile devices or tablets where if there is functionality triggered by a single pointer, at least one of the following is true:
 

--- a/source/sc/2.5.3.html.md.erb
+++ b/source/sc/2.5.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html)
 
 For user interface components with labels that include text or images of text, the [Accessible name](https://www.w3.org/TR/WCAG21/#dfn-name) contains the text that is presented visually.
 

--- a/source/sc/2.5.3.html.md.erb
+++ b/source/sc/2.5.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html)
 
 For user interface components with labels that include text or images of text, the [Accessible name](https://www.w3.org/TR/WCAG21/#dfn-name) contains the text that is presented visually.
 

--- a/source/sc/2.5.4.html.md.erb
+++ b/source/sc/2.5.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/motion-actuation.html)
 
 In a page or on a mobile device functionality that can be operated by device motion or user motion can also be operated by alternatives like buttons, links or other controls. There should be a way for disabling responding motion, unless the motion can operate in an accessible way or is essential
 

--- a/source/sc/2.5.4.html.md.erb
+++ b/source/sc/2.5.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation.html)
 
 In a page or on a mobile device functionality that can be operated by device motion or user motion can also be operated by alternatives like buttons, links or other controls. There should be a way for disabling responding motion, unless the motion can operate in an accessible way or is essential
 

--- a/source/sc/2.5.7.html.md.erb
+++ b/source/sc/2.5.7.html.md.erb
@@ -11,7 +11,7 @@ Don't rely on the user having to drag something on their screen to complete a ta
 
 > All functionality that uses a dragging movement for operation can be achieved by a single pointer without dragging, unless dragging is essential or the functionality is determined by the user agent and not modified by the author.
 
-[Understanding 2.5.8 Dragging Movements](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html)
+Check the official guidance for [Understanding 2.5.8 Dragging Movements](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html)
 
 ## What this means
 

--- a/source/sc/2.5.8.html.md.erb
+++ b/source/sc/2.5.8.html.md.erb
@@ -74,7 +74,7 @@ This could be fixed by making each link at least 24 pixels wide.
 
 ## Related success criteria
 
-To achieve AAA compliance and meet [2.5.5 Target Size (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced), every component should be at least 44 pixels high and 44 pixels wide.
+To achieve AAA compliance and follow the official guidance for [Understanding 2.5.5 Target Size (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced), every component should be at least 44 pixels high and 44 pixels wide.
 
 ## Useful resources
 

--- a/source/sc/2.5.8.html.md.erb
+++ b/source/sc/2.5.8.html.md.erb
@@ -11,7 +11,7 @@ Make sure clickable elements on a page are large enough for a user to easily sel
 
 > "The size of the target for pointer inputs is at least 24 by 24 CSS pixels…" (with exceptions)
 
-[Understanding 2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum)
+Check the official guidance for [Understanding 2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum)
 
 ## What this means
 

--- a/source/sc/3.1.1.html.md.erb
+++ b/source/sc/3.1.1.html.md.erb
@@ -7,9 +7,9 @@ updated: 2025-07
 
 ## What WCAG says:  
 
-The default human language of each web page can be programmatically determined.
+> The default human language of each web page can be programmatically determined.
 
-[Understanding 3.1.1 Language of Page](https://www.w3.org/WAI/WCAG22/Understanding/language-of-page.html)
+Check the official guidance for [Understanding 3.1.1 Language of Page](https://www.w3.org/WAI/WCAG22/Understanding/language-of-page.html)
 
 ## What this means  
 

--- a/source/sc/3.1.2.html.md.erb
+++ b/source/sc/3.1.2.html.md.erb
@@ -7,9 +7,9 @@ updated: 2025-07
 
 ## What WCAG says:
 
-"The human language of each passage or phrase in the content can be programmatically determined" (with exceptions)
+> "The human language of each passage or phrase in the content can be programmatically determined" (with exceptions)
 
-[Understanding 3.1.2 Language of Parts](https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts.html)
+Check the official guidance for [Understanding 3.1.2 Language of Parts](https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts.html)
 
 ## What this means
 

--- a/source/sc/3.2.1.html.md.erb
+++ b/source/sc/3.2.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html)
 
 When a keyboard user focuses on a control it must not cause a change of context, such as loading a new page/tab. This stops unexpected things happening without screen reader and screen magnifer users being aware of it.
 

--- a/source/sc/3.2.1.html.md.erb
+++ b/source/sc/3.2.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/on-focus.html)
 
 When a keyboard user focuses on a control it must not cause a change of context, such as loading a new page/tab. This stops unexpected things happening without screen reader and screen magnifer users being aware of it.
 

--- a/source/sc/3.2.2.html.md.erb
+++ b/source/sc/3.2.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/on-input.html)
 
 Changing the setting of any user interface component does not automatically cause a change of context unless the user has been advised of the behaviour before using the component.
 

--- a/source/sc/3.2.2.html.md.erb
+++ b/source/sc/3.2.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html)
 
 Changing the setting of any user interface component does not automatically cause a change of context unless the user has been advised of the behaviour before using the component.
 

--- a/source/sc/3.2.3.html.md.erb
+++ b/source/sc/3.2.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/consistent-navigation.html)
 
 When ways to navigate content are repeated on multiple pages, they must be presented in a consistent manner. This makes it easier for people to learn how to navigate the service, and it enables people to develop strategies (like using screen reader shortcuts) for more efficient navigation.
 

--- a/source/sc/3.2.3.html.md.erb
+++ b/source/sc/3.2.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation.html)
 
 When ways to navigate content are repeated on multiple pages, they must be presented in a consistent manner. This makes it easier for people to learn how to navigate the service, and it enables people to develop strategies (like using screen reader shortcuts) for more efficient navigation.
 

--- a/source/sc/3.2.4.html.md.erb
+++ b/source/sc/3.2.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html)
 
 When features with the same functionality are used in multiple places, they must be identified in a consistent way. This helps screen reader users correctly identify the type and purpose of the functionality.
 

--- a/source/sc/3.2.4.html.md.erb
+++ b/source/sc/3.2.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/consistent-identification.html)
 
 When features with the same functionality are used in multiple places, they must be identified in a consistent way. This helps screen reader users correctly identify the type and purpose of the functionality.
 

--- a/source/sc/3.2.6.html.md.erb
+++ b/source/sc/3.2.6.html.md.erb
@@ -18,7 +18,7 @@ Show help options in a consistent place across pages.
 >
 > (with additional notes)
 
-[Understanding 3.2.6 Consistent Help](https://www.w3.org/WAI/WCAG22/Understanding/consistent-help)
+Check the official guidance for [Understanding 3.2.6 Consistent Help](https://www.w3.org/WAI/WCAG22/Understanding/consistent-help)
 
 ## What this means
 

--- a/source/sc/3.3.1.html.md.erb
+++ b/source/sc/3.3.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html)
 
 When an error occurs the user is informed what caused the error, and the error is described in text. This ensures that the error is available to people who cannot see, distinguish colours, or understand icons and other visual cues.
 

--- a/source/sc/3.3.1.html.md.erb
+++ b/source/sc/3.3.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html)
 
 When an error occurs the user is informed what caused the error, and the error is described in text. This ensures that the error is available to people who cannot see, distinguish colours, or understand icons and other visual cues.
 

--- a/source/sc/3.3.2.html.md.erb
+++ b/source/sc/3.3.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-12
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html)
 
 When data must be entered in a specific format or in a particular way, clear instructions must be associated with the form field. This ensures that everyone understands any requirements for entering data, and does so in a way that ensures that people unable to see the information are made aware of it by their screen readers.
 

--- a/source/sc/3.3.2.html.md.erb
+++ b/source/sc/3.3.2.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-12
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html)
 
 When data must be entered in a specific format or in a particular way, clear instructions must be associated with the form field. This ensures that everyone understands any requirements for entering data, and does so in a way that ensures that people unable to see the information are made aware of it by their screen readers.
 

--- a/source/sc/3.3.3.html.md.erb
+++ b/source/sc/3.3.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-08
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html)
 
 When an error is detected, suggestions for correcting the issue must be provided unless the suggestion compromises security. This helps everyone resolve issues more easily, but especially people with cognitive disabilities who find processing information difficult.
 

--- a/source/sc/3.3.3.html.md.erb
+++ b/source/sc/3.3.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-08
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion.html)
 
 When an error is detected, suggestions for correcting the issue must be provided unless the suggestion compromises security. This helps everyone resolve issues more easily, but especially people with cognitive disabilities who find processing information difficult.
 

--- a/source/sc/3.3.4.html.md.erb
+++ b/source/sc/3.3.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/error-prevention-legal-financial-data.html)
 
 When completion of a form causes a legal commitment, triggers a financial transaction, or gives consent for personal data to be updated or changed, the user must be able to review, correct, and confirm that the information they have entered is correct, or they must be able to reverse the decision. This provides safeguards to prevent people with disabilities, and indeed all users, from making avoidable mistakes.
 

--- a/source/sc/3.3.4.html.md.erb
+++ b/source/sc/3.3.4.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data.html)
 
 When completion of a form causes a legal commitment, triggers a financial transaction, or gives consent for personal data to be updated or changed, the user must be able to review, correct, and confirm that the information they have entered is correct, or they must be able to reverse the decision. This provides safeguards to prevent people with disabilities, and indeed all users, from making avoidable mistakes.
 

--- a/source/sc/3.3.7.html.md.erb
+++ b/source/sc/3.3.7.html.md.erb
@@ -16,7 +16,7 @@ Help people avoid having to re-enter information.
 > 
 > (with exceptions)
 
-[Understanding 3.3.7 Redundant Entry](https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry)
+Check the official guidance for [Understanding 3.3.7 Redundant Entry](https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry)
 
 ## What this means
 

--- a/source/sc/3.3.8.html.md.erb
+++ b/source/sc/3.3.8.html.md.erb
@@ -11,7 +11,7 @@ Make it as easy as possible to sign in with less mental effort. Don't make peopl
 
 > “A cognitive function test (such as remembering a password or solving a puzzle) is not required for any step in an authentication process…” (with exceptions)
 
-[Understanding 3.3.8 Accessible Authentication (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum)
+Check the official guidance for [Understanding 3.3.8 Accessible Authentication (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum)
 
 ## What this means
 

--- a/source/sc/3.3.8.html.md.erb
+++ b/source/sc/3.3.8.html.md.erb
@@ -78,7 +78,7 @@ This could be improved by replacing the question with an object recognition test
 ## Related success criteria
 
 * [3.3.7 Redundant Entry (A)](3.3.7.html) aims to make it easier for users to re-enter information as part of a service.
-* To achieve AAA compliance and meet [3.3.9 Accessible Authentication (Enhanced) (AAA)](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced), you need to meet the AA criterion without relying on users recognising objects or content they've already provided.
+* To achieve AAA compliance and meet the official guidance for [Understanding 3.3.9 Accessible Authentication (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced), you need to meet the AA criterion without relying on users recognising objects or content they've already provided.
 
 ## Useful resources
 

--- a/source/sc/4.1.1.html.md.erb
+++ b/source/sc/4.1.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/parsing.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/parsing.html)
 
 The code of the page must not cause browser or assistive technology conflicts. This ensures that content and functionality is presented in a way that works reliably across all supported browsers and assistive technologies.
 

--- a/source/sc/4.1.1.html.md.erb
+++ b/source/sc/4.1.1.html.md.erb
@@ -5,7 +5,7 @@ updated: 2018-07
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/parsing.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/parsing.html)
 
 The code of the page must not cause browser or assistive technology conflicts. This ensures that content and functionality is presented in a way that works reliably across all supported browsers and assistive technologies.
 

--- a/source/sc/4.1.2.html.md.erb
+++ b/source/sc/4.1.2.html.md.erb
@@ -9,7 +9,7 @@ updated: 2025-08
 
 > For all user interface components … the name and role can be programmatically determined; states, properties, and values that can be set by the user can be programmatically set; and notification of changes to these items is available to … assistive technologies.
 
-[Understanding 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value)
+Check the official guidance for [Understanding 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value)
 
 ## What this means
 

--- a/source/sc/4.1.3.html.md.erb
+++ b/source/sc/4.1.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html)
 
 There are different situations where a status message needs to be shown in a way that assistive technologies understand. These messages need to be presented to the user without receiving focus themselves, or disturbing the user's place in a page. 
 

--- a/source/sc/4.1.3.html.md.erb
+++ b/source/sc/4.1.3.html.md.erb
@@ -5,7 +5,7 @@ updated: 2019-02
 
 # <%= current_page.data.title %>
 
-[Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html)
+Check the official guidance for [Understanding <%= current_page.data.title %>](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html)
 
 There are different situations where a status message needs to be shown in a way that assistive technologies understand. These messages need to be presented to the user without receiving focus themselves, or disturbing the user's place in a page. 
 


### PR DESCRIPTION
This PR updates the format of all Understanding links and brings them up to date, based on a format decided within our working group. It:

- updates all "Understanding" links to refer to the "official guidance" in surrounding text, including older pages
- tweaks the wording for references to AAA criteria, to be more consistent with the above change
- updates some links pointing from version 2.1 to version 2.2 of the Understanding pages (from my previous testing, this is a direct change in the links from `WCAG21` to `WCAG22`)
- adds "quote" formats to two success criteria (3.1.1 and 3.1.2) that were missing them, directly above the Understanding links

I've spot checked several pages locally and they work fine, but haven't done an exhaustive test.